### PR TITLE
Move the migration helper scripts to commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,7 @@
 !app/logs/.gitkeep
 /build/
 /vendor/
-/bin/*
-!/bin/doctrine-diff
-!/bin/doctrine-migrate
+/bin
 /composer.phar
 /cache.properties
 /app/SymfonyRequirements.php

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -36,6 +36,7 @@ class AppKernel extends Kernel
             new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
             new Surfnet\StepupMiddleware\CommandHandlingBundle\SurfnetStepupMiddlewareCommandHandlingBundle(),
             new Surfnet\StepupMiddleware\ApiBundle\SurfnetStepupMiddlewareApiBundle(),
+            new Surfnet\StepupMiddleware\MiddlewareBundle\MiddlewareBundle(),
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {

--- a/bin/doctrine-diff
+++ b/bin/doctrine-diff
@@ -1,3 +1,0 @@
-#!/bin/bash
-BASEDIR=$(dirname $0)
-(cd $BASEDIR/.. && app/console doc:mig:diff --em=deploy --filter-expression='~^(?!event_stream).*$~')

--- a/bin/doctrine-migrate
+++ b/bin/doctrine-migrate
@@ -1,3 +1,0 @@
-#!/bin/bash
-BASEDIR=$(dirname $0)
-(cd $BASEDIR/.. && app/console doc:mig:mig --em=deploy)

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrationsDiffDoctrineCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrationsDiffDoctrineCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Copyright 2014 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrationsDiffDoctrineCommand extends Command
+{
+    protected function configure()
+    {
+        $this->setName('middleware:migrations:diff');
+        $this->setDescription('Performs a mapping/database diff using the correct entity manager');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->getApplication()->doRun(
+            new StringInput("doc:mig:diff --em=deploy --filter-expression='~^(?!event_stream).*$~'"),
+            $output
+        );
+    }
+}

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrationsMigrateDoctrineCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrationsMigrateDoctrineCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Copyright 2014 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrationsMigrateDoctrineCommand extends Command
+{
+    protected function configure()
+    {
+        $this->setName('middleware:migrations:migrate');
+        $this->setDescription('Performs database migrations using the correct entity manager');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->getApplication()->doRun(new StringInput("doc:mig:mig --em=deploy"), $output);
+    }
+}

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/MiddlewareBundle.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/MiddlewareBundle.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Copyright 2014 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\MiddlewareBundle;
+
+use Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\MigrationsDiffDoctrineCommand;
+use Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\MigrationsMigrateDoctrineCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class MiddlewareBundle extends Bundle
+{
+    public function registerCommands(Application $application)
+    {
+        $application->add(new MigrationsDiffDoctrineCommand());
+        $application->add(new MigrationsMigrateDoctrineCommand());
+    }
+}


### PR DESCRIPTION
Running as a "[nested command](https://github.com/SURFnet/Stepup-Middleware/blob/7c1365ae00f6a17b0f6b6d3e4ecb657b1ef29f6f/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrationsDiffDoctrineCommand.php#L37)", because the [original command is so tightly coupled to InputInterface](https://github.com/doctrine/DoctrineMigrationsBundle/blob/81575a4316951125ce408c70f30547c77d98f78a/Command/MigrationsDiffDoctrineCommand.php#L46).

Ready for review @DRvanR.
