### PR TITLE
Ensure displayed ART and logged ART are equal.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1904,12 +1904,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SURFnet/Stepup-bundle.git",
-                "reference": "5d3c5eb10a28d49a0a78fc43b47285b4738a2e65"
+                "reference": "6925b078772a8364655206299164e3d336c4d469"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SURFnet/Stepup-bundle/zipball/5d3c5eb10a28d49a0a78fc43b47285b4738a2e65",
-                "reference": "5d3c5eb10a28d49a0a78fc43b47285b4738a2e65",
+                "url": "https://api.github.com/repos/SURFnet/Stepup-bundle/zipball/6925b078772a8364655206299164e3d336c4d469",
+                "reference": "6925b078772a8364655206299164e3d336c4d469",
                 "shasum": ""
             },
             "require": {
@@ -1945,7 +1945,7 @@
                 "suaas",
                 "surfnet"
             ],
-            "time": "2014-11-12 13:49:13"
+            "time": "2015-03-13 10:49:44"
         },
         {
             "name": "swiftmailer/swiftmailer",


### PR DESCRIPTION
This was fixed in the Stepup bundle, but not installed in all apps.