### PR TITLE
Don't set any cookies to persist the user's security context

### DIFF
--- a/app/DoctrineMigrations/Version20150528154959.php
+++ b/app/DoctrineMigrations/Version20150528154959.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Surfnet\StepupMiddleware\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20150528154959 extends AbstractMigration implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $gatewaySchema = $this->getGatewaySchema();
+
+        $this->addSql(sprintf('ALTER TABLE %s.second_factor ADD display_locale VARCHAR(255) NOT NULL', $gatewaySchema));
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $gatewaySchema = $this->getGatewaySchema();
+
+        $this->addSql(sprintf('ALTER TABLE %s.second_factor DROP display_locale', $gatewaySchema));
+    }
+
+    /**
+     * @return string
+     */
+    private function getGatewaySchema()
+    {
+        return $this->container->getParameter('database_gateway_name');
+    }
+}

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -6,6 +6,7 @@ security:
         api:
             http_basic: ~
             entry_point: surfnet_stepup_middleware_api.security.json_basic_auth_entry_point
+            stateless:  true
 
     access_control:
         - { path: ^/management, roles: [ROLE_MANAGEMENT] } # can be expanded with hosts: or ip:

--- a/src/Surfnet/Stepup/Identity/Event/YubikeySecondFactorBootstrappedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/YubikeySecondFactorBootstrappedEvent.php
@@ -22,6 +22,7 @@ use Surfnet\Stepup\Identity\AuditLog\Metadata;
 use Surfnet\Stepup\IdentifyingData\Value\IdentifyingDataId;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\Stepup\Identity\Value\Locale;
 use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\Stepup\Identity\Value\YubikeyPublicId;
@@ -38,6 +39,11 @@ final class YubikeySecondFactorBootstrappedEvent extends IdentityEvent
      * @var Institution
      */
     public $institution;
+
+    /**
+     * @var \Surfnet\Stepup\Identity\Value\Locale
+     */
+    public $preferredLocale;
 
     /**
      * @var IdentifyingDataId
@@ -58,6 +64,7 @@ final class YubikeySecondFactorBootstrappedEvent extends IdentityEvent
         IdentityId $identityId,
         NameId $nameId,
         Institution $institution,
+        Locale $preferredLocale,
         IdentifyingDataId $identifyingDataId,
         SecondFactorId $secondFactorId,
         YubikeyPublicId $yubikeyPublicId
@@ -66,6 +73,7 @@ final class YubikeySecondFactorBootstrappedEvent extends IdentityEvent
 
         $this->nameId = $nameId;
         $this->institution = $institution;
+        $this->preferredLocale = $preferredLocale;
         $this->identifyingDataId = $identifyingDataId;
         $this->secondFactorId = $secondFactorId;
         $this->yubikeyPublicId = $yubikeyPublicId;
@@ -89,7 +97,8 @@ final class YubikeySecondFactorBootstrappedEvent extends IdentityEvent
             'identity_id'          => (string) $this->identityId,
             'name_id'              => (string) $this->nameId,
             'identity_institution' => (string) $this->identityInstitution,
-            'identifying_data_id' => (string) $this->identifyingDataId,
+            'preferred_locale'     => (string) $this->preferredLocale,
+            'identifying_data_id'  => (string) $this->identifyingDataId,
             'second_factor_id'     => (string) $this->secondFactorId,
             'yubikey_public_id'    => (string) $this->yubikeyPublicId,
         ];
@@ -101,6 +110,7 @@ final class YubikeySecondFactorBootstrappedEvent extends IdentityEvent
             new IdentityId($data['identity_id']),
             new NameId($data['name_id']),
             new Institution($data['identity_institution']),
+            new Locale($data['preferred_locale']),
             new IdentifyingDataId($data['identifying_data_id']),
             new SecondFactorId($data['second_factor_id']),
             new YubikeyPublicId($data['yubikey_public_id'])

--- a/src/Surfnet/Stepup/Identity/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Identity.php
@@ -118,7 +118,7 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
     private $registrationAuthority;
 
     /**
-     * @var string
+     * @var Locale
      */
     private $preferredLocale;
 
@@ -172,6 +172,7 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
                 $this->id,
                 $this->nameId,
                 $this->institution,
+                $this->preferredLocale,
                 $this->identifyingDataId,
                 $secondFactorId,
                 $yubikeyPublicId

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
@@ -110,6 +110,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     $identityId,
                     new NameId('N-ID'),
                     new Institution('Institution'),
+                    new Locale('nl_NL'),
                     IdentifyingDataId::fromIdentityId($identityId),
                     new SecondFactorId('SF-ID'),
                     new YubikeyPublicId('Y-ID')
@@ -664,6 +665,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     $authorityId,
                     $authorityNameId,
                     $authorityInstitution,
+                    new Locale('en_GB'),
                     $authorityIdentifyingDataId,
                     new SecondFactorId($this->uuid()),
                     new YubikeyPublicId('ccccvkdowiej')

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/RegistrationAuthorityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/RegistrationAuthorityCommandHandlerTest.php
@@ -99,6 +99,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
                     $identityId,
                     $nameId,
                     $institution,
+                    new Locale('en_GB'),
                     $identifyingDataId,
                     $secondFactorId,
                     $secondFactorPublicId
@@ -181,6 +182,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
                         $identityId,
                         $nameId,
                         $institution,
+                        new Locale('en_GB'),
                         $identifyingDataId,
                         $secondFactorId,
                         $secondFactorPublicId
@@ -236,6 +238,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
                         $identityId,
                         $nameId,
                         $institution,
+                        new Locale('en_GB'),
                         $identifyingDataId,
                         $secondFactorId,
                         $secondFactorPublicId
@@ -281,6 +284,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
                         $identityId,
                         $nameId,
                         $institution,
+                        new Locale('en_GB'),
                         $identifyingDataId,
                         $secondFactorId,
                         $secondFactorPublicId
@@ -336,6 +340,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
                         $identityId,
                         $nameId,
                         $institution,
+                        new Locale('en_GB'),
                         $identifyingDataId,
                         $secondFactorId,
                         $secondFactorPublicId
@@ -391,6 +396,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
                         $identityId,
                         $nameId,
                         $institution,
+                        new Locale('en_GB'),
                         $identifyingDataId,
                         $secondFactorId,
                         $secondFactorPublicId
@@ -455,6 +461,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
                         $identityId,
                         $nameId,
                         $institution,
+                        new Locale('en_GB'),
                         $identifyingDataId,
                         $secondFactorId,
                         $secondFactorPublicId

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
@@ -295,6 +295,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $authorityId,
                     $authorityNameId,
                     $authorityInstitution,
+                    new Locale('en_GB'),
                     $authorityIdentifyingDataId,
                     new SecondFactorId(static::uuid()),
                     new YubikeyPublicId('ccccvkdowiej')
@@ -374,6 +375,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $authorityId,
                     $authorityNameId,
                     $authorityInstitution,
+                    new Locale('en_GB'),
                     $authorityIdentifyingDataId,
                     new SecondFactorId(static::uuid()),
                     new YubikeyPublicId('ccccvkdowiej')
@@ -464,6 +466,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $authorityId,
                     $authorityNameId,
                     $authorityInstitution,
+                    new Locale('en_GB'),
                     $authorityIdentifyingDataId,
                     new SecondFactorId(static::uuid()),
                     new YubikeyPublicId('ccccvkdowiej')

--- a/src/Surfnet/StepupMiddleware/GatewayBundle/Entity/SecondFactor.php
+++ b/src/Surfnet/StepupMiddleware/GatewayBundle/Entity/SecondFactor.php
@@ -62,6 +62,15 @@ class SecondFactor
     private $institution;
 
     /**
+     * In which language to display any second factor verification screens.
+     *
+     * @var string
+     *
+     * @ORM\Column
+     */
+    public $displayLocale;
+
+    /**
      * @var string
      *
      * @ORM\Column(length=36)
@@ -86,6 +95,7 @@ class SecondFactor
         $identityId,
         $nameId,
         $institution,
+        $displayLocale,
         $secondFactorId,
         $secondFactorIdentifier,
         $secondFactorType
@@ -94,6 +104,7 @@ class SecondFactor
         $this->identityId             = $identityId;
         $this->nameId                 = $nameId;
         $this->institution            = $institution;
+        $this->displayLocale          = $displayLocale;
         $this->secondFactorId         = $secondFactorId;
         $this->secondFactorIdentifier = $secondFactorIdentifier;
         $this->secondFactorType       = $secondFactorType;

--- a/src/Surfnet/StepupMiddleware/GatewayBundle/Projector/SecondFactorProjector.php
+++ b/src/Surfnet/StepupMiddleware/GatewayBundle/Projector/SecondFactorProjector.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupMiddleware\GatewayBundle\Projector;
 
 use Broadway\ReadModel\Projector;
 use Surfnet\Stepup\Identity\Event\CompliedWithVettedSecondFactorRevocationEvent;
+use Surfnet\Stepup\Identity\Event\LocalePreferenceExpressedEvent;
 use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
 use Surfnet\Stepup\Identity\Event\VettedSecondFactorRevokedEvent;
 use Surfnet\Stepup\Identity\Event\YubikeySecondFactorBootstrappedEvent;
@@ -49,6 +50,7 @@ class SecondFactorProjector extends Projector
                 (string) $event->identityId,
                 (string) $event->nameId,
                 (string) $event->identityInstitution,
+                (string) $event->preferredLocale,
                 (string) $event->secondFactorId,
                 (string) $event->yubikeyPublicId,
                 'yubikey'
@@ -63,6 +65,7 @@ class SecondFactorProjector extends Projector
                 (string) $event->identityId,
                 (string) $event->nameId,
                 (string) $event->identityInstitution,
+                (string) $event->preferredLocale,
                 (string) $event->secondFactorId,
                 $event->secondFactorIdentifier,
                 $event->secondFactorType
@@ -97,5 +100,15 @@ class SecondFactorProjector extends Projector
         }
 
         $this->repository->remove($secondFactor);
+    }
+
+    protected function applyLocalePreferenceExpressedEvent(LocalePreferenceExpressedEvent $event)
+    {
+        $secondFactors = $this->repository->findByIdentityId($event->identityId);
+
+        foreach ($secondFactors as $secondFactor) {
+            $secondFactor->displayLocale = (string) $event->preferredLocale;
+            $this->repository->save($secondFactor);
+        }
     }
 }

--- a/src/Surfnet/StepupMiddleware/GatewayBundle/Repository/SecondFactorRepository.php
+++ b/src/Surfnet/StepupMiddleware/GatewayBundle/Repository/SecondFactorRepository.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupMiddleware\GatewayBundle\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\StepupMiddleware\GatewayBundle\Entity\SecondFactor;
 
@@ -40,6 +41,15 @@ class SecondFactorRepository extends EntityRepository
     public function findOneBySecondFactorId(SecondFactorId $secondFactorId)
     {
         return $this->findOneBy(['secondFactorId' => (string) $secondFactorId]);
+    }
+
+    /**
+     * @param IdentityId $identityId
+     * @return SecondFactor[]
+     */
+    public function findByIdentityId(IdentityId $identityId)
+    {
+        return $this->findBy(['identityId' => (string) $identityId]);
     }
 
     /**


### PR DESCRIPTION
As the Middleware API is based on Basic authentication, no cookies
need to be set to keep the consumer authenticated. Also, no other
needs the be persisted from request to request.

Based on #81 so I don't have to keep wiping my event stream. Merge or cherry-pick into develop.