### PR TITLE
Add 'second_factor_only' SP configuration

### DIFF
--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/ConfigurationValidationTest.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/ConfigurationValidationTest.php
@@ -71,7 +71,11 @@ final class ConfigurationValidationTest extends TestCase
         $validator->validate(json_encode($configuration), new HasValidConfigurationStructure());
 
         // PHPUnit assertions are more informative than Mockery's method-should-be-called-1-times-but-called-0-times.
-        $this->assertEquals($expectedPropertyPath, $actualPropertyPath, sprintf("Actual path to erroneous property doesn't match expected path (%s)", $errorMessage));
+        $this->assertEquals(
+            $expectedPropertyPath,
+            $actualPropertyPath,
+            sprintf("Actual path to erroneous property doesn't match expected path (%s)", $errorMessage)
+        );
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/empty_idp_loas.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/empty_idp_loas.php
@@ -34,6 +34,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/empty_sp_acs.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/empty_sp_acs.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/empty_sp_loas.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/empty_sp_loas.php
@@ -27,6 +27,8 @@ return [
                     "public_key" => "MIIE...",
                     "acs"        => ["https://entity.tld/consume-assertion"],
                     "loa"        => [],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_blacklisted_encryption_algorithm.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_blacklisted_encryption_algorithm.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => [9],
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_blacklisted_encryption_algorithms.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_blacklisted_encryption_algorithms.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => 9,
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_email_template_locale.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_email_template_locale.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idp.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idp.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idp_entity_id.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idp_entity_id.php
@@ -36,6 +36,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idps.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idps.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_acs.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_acs.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_assertion_encryption_enabled.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_assertion_encryption_enabled.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled" => 9,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_entity_id.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_entity_id.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_loa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_loa.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => 3,
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_public_key.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_public_key.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_second_factor_only.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_second_factor_only.php
@@ -17,17 +17,10 @@
  */
 
 return [
-    'expectedPropertyPath' => 'gateway.identity_providers[0].loa',
+    'expectedPropertyPath' => 'gateway.service_providers[0].second_factor_only',
     'configuration' => [
         'gateway' => [
-            'identity_providers' => [
-                [
-                    "entity_id" => "http://idp.tld/metadata",
-                    "loa" => [
-                        "__default__" => 9,
-                    ]
-                ]
-            ],
+            'identity_providers' => [],
             'service_providers' => [
                 [
                     "entity_id"  => "https://entity.tld/id",
@@ -36,7 +29,7 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
-                    "second_factor_only" => false,
+                    "second_factor_only" => 'true',
                     "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_second_factor_only_nameid_patterns.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_second_factor_only_nameid_patterns.php
@@ -17,17 +17,10 @@
  */
 
 return [
-    'expectedPropertyPath' => 'gateway.identity_providers[0].loa',
+    'expectedPropertyPath' => 'gateway.service_providers[0].second_factor_only_nameid_patterns',
     'configuration' => [
         'gateway' => [
-            'identity_providers' => [
-                [
-                    "entity_id" => "http://idp.tld/metadata",
-                    "loa" => [
-                        "__default__" => 9,
-                    ]
-                ]
-            ],
+            'identity_providers' => [],
             'service_providers' => [
                 [
                     "entity_id"  => "https://entity.tld/id",
@@ -36,8 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
-                    "second_factor_only" => false,
-                    "second_factor_only_nameid_patterns" => [],
+                    "second_factor_only" => 'true',
+                    "second_factor_only_nameid_patterns" => "urn:*",
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_second_factor_only_nameid_patterns.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_second_factor_only_nameid_patterns.php
@@ -29,7 +29,7 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
-                    "second_factor_only" => 'true',
+                    "second_factor_only" => true,
                     "second_factor_only_nameid_patterns" => "urn:*",
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sraa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sraa.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sraas.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sraas.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_email_template_confirm_email.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_email_template_confirm_email.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_email_template_locale.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_email_template_locale.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_email_template_registration_code.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_email_template_registration_code.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_acs.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_acs.php
@@ -28,6 +28,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_assertion_encryption_enabled.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_assertion_encryption_enabled.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "blacklisted_encryption_algorithms" => []
                 ]
             ],

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_blacklisted_encryption_algorithms.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_blacklisted_encryption_algorithms.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                 ]
             ],

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_entity_id.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_entity_id.php
@@ -28,6 +28,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_loas.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_loas.php
@@ -26,6 +26,8 @@ return [
                     "entity_id"  => "https://entity.tld/id",
                     "public_key" => "MIIE...",
                     "acs"        => ["https://entity.tld/consume-assertion"],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_public_key.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_public_key.php
@@ -28,6 +28,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_email_template.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_email_template.php
@@ -29,6 +29,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_gateway.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_gateway.php
@@ -30,6 +30,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_gateway_sp.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_gateway_sp.php
@@ -30,6 +30,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_root.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_root.php
@@ -30,6 +30,8 @@ return [
                     "loa"        => [
                         "__default__" => "https://entity.tld/authentication/loa2",
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_array_email_templates.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_array_email_templates.php
@@ -29,6 +29,8 @@ return [
                     'loa' => [
                         '__default__' => 'http://gateway.tld/loa/1'
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ],

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_array_sraa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_array_sraa.php
@@ -29,6 +29,8 @@ return [
                     'loa' => [
                         '__default__' => 'http://gateway.tld/loa/1'
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ],

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_strings_sraa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_strings_sraa.php
@@ -29,6 +29,8 @@ return [
                     'loa' => [
                         '__default__' => 'http://gateway.tld/loa/1'
                     ],
+                    "second_factor_only" => false,
+                    "second_factor_only_nameid_patterns" => [],
                     "assertion_encryption_enabled"      => false,
                     "blacklisted_encryption_algorithms" => []
                 ],

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ServiceProviderConfigurationValidator.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ServiceProviderConfigurationValidator.php
@@ -34,6 +34,7 @@ class ServiceProviderConfigurationValidator implements ConfigurationValidatorInt
             'loa',
             'assertion_encryption_enabled',
             'second_factor_only',
+            'second_factor_only_nameid_patterns',
             'blacklisted_encryption_algorithms',
         ];
         StepupAssert::keysMatch(
@@ -58,6 +59,11 @@ class ServiceProviderConfigurationValidator implements ConfigurationValidatorInt
         $this->validateBooleanValue(
           $configuration,
           'second_factor_only',
+          $propertyPath
+        );
+        $this->validateListOfNameIdPatterns(
+          $configuration,
+          'second_factor_only_nameid_patterns',
           $propertyPath
         );
         $this->validateStringValues(
@@ -124,5 +130,19 @@ class ServiceProviderConfigurationValidator implements ConfigurationValidatorInt
         Assert::isArray($value, 'must be an object', $path);
         Assert::keyExists($value, '__default__', "must have the default loa set on the '__default__' property", $path);
         Assert::allString($value, 'all properties must contain strings as values', $path);
+    }
+
+    /**
+     * @param array $configuration
+     * @param string $name
+     * @param string $propertyPath
+     */
+    private function validateListOfNameIdPatterns($configuration, $name, $propertyPath)
+    {
+        $value = $configuration[$name];
+        $propertyPath = $propertyPath . '.' . $name;
+
+        Assert::isArray($value, 'must contain an array', $propertyPath);
+        Assert::allString($value, 'must be an array of strings', $propertyPath);
     }
 }

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ServiceProviderConfigurationValidator.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ServiceProviderConfigurationValidator.php
@@ -57,14 +57,14 @@ class ServiceProviderConfigurationValidator implements ConfigurationValidatorInt
             $propertyPath
         );
         $this->validateBooleanValue(
-          $configuration,
-          'second_factor_only',
-          $propertyPath
+            $configuration,
+            'second_factor_only',
+            $propertyPath
         );
         $this->validateListOfNameIdPatterns(
-          $configuration,
-          'second_factor_only_nameid_patterns',
-          $propertyPath
+            $configuration,
+            'second_factor_only_nameid_patterns',
+            $propertyPath
         );
         $this->validateStringValues(
             $configuration,

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ServiceProviderConfigurationValidator.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ServiceProviderConfigurationValidator.php
@@ -33,7 +33,8 @@ class ServiceProviderConfigurationValidator implements ConfigurationValidatorInt
             'acs',
             'loa',
             'assertion_encryption_enabled',
-            'blacklisted_encryption_algorithms'
+            'second_factor_only',
+            'blacklisted_encryption_algorithms',
         ];
         StepupAssert::keysMatch(
             $configuration,
@@ -53,6 +54,11 @@ class ServiceProviderConfigurationValidator implements ConfigurationValidatorInt
             $configuration,
             'assertion_encryption_enabled',
             $propertyPath
+        );
+        $this->validateBooleanValue(
+          $configuration,
+          'second_factor_only',
+          $propertyPath
         );
         $this->validateStringValues(
             $configuration,


### PR DESCRIPTION
Adds and requires "second_factor_only" boolean and "second_factor_only_nameid_patterns" list of strings configuration for Service Providers.