### PR TITLE
Remove the RaCandidates by using the EntityManager

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
@@ -52,12 +52,12 @@ class RaCandidateRepository extends EntityRepository
     }
 
     /**
-     * @param string[] $sraaList
+     * @param string[] $nameIds
      * @return void
      */
-    public function removeByNameIds($sraaList)
+    public function removeByNameIds($nameIds)
     {
-        $raCandidates = $this->findByNameIds($sraaList);
+        $raCandidates = $this->findByNameIds($nameIds);
 
         $em = $this->getEntityManager();
         foreach ($raCandidates as $raCandidate) {

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
@@ -41,16 +41,30 @@ class RaCandidateRepository extends EntityRepository
      */
     public function removeByIdentityId(IdentityId $identityId)
     {
-        $queryBuilder = $this->getEntityManager()->createQueryBuilder();
+        $raCandidate = $this->findByIdentityId($identityId);
 
-        $queryBuilder
-            ->delete($this->_entityName, 'rac')
-            ->where('rac.identityId = :identityId')
-            ->setParameter('identityId', (string) $identityId)
-            ->getQuery()
-            ->execute();
+        if (!$raCandidate) {
+            return;
+        }
 
+        $this->getEntityManager()->remove($raCandidate);
         $this->getEntityManager()->flush();
+    }
+
+    /**
+     * @param string[] $sraaList
+     * @return void
+     */
+    public function removeByNameIds($sraaList)
+    {
+        $raCandidates = $this->findByNameIds($sraaList);
+
+        $em = $this->getEntityManager();
+        foreach ($raCandidates as $raCandidate) {
+            $em->remove($raCandidate);
+        }
+
+        $em->flush();
     }
 
     /**
@@ -79,21 +93,16 @@ class RaCandidateRepository extends EntityRepository
     }
 
     /**
-     * @param array $sraaList
-     * @return void
+     * @param string[] $sraaList
+     * @return RaCandidate[]
      */
-    public function removeByNameIds(array $sraaList)
+    public function findByNameIds(array $sraaList)
     {
-        $queryBuilder = $this->getEntityManager()->createQueryBuilder();
-
-        $queryBuilder
-            ->delete($this->_entityName, 'rac')
+        return $this->createQueryBuilder('rac')
             ->where('rac.nameId IN (:sraaList)')
             ->setParameter('sraaList', $sraaList)
             ->getQuery()
-            ->execute();
-
-        $this->getEntityManager()->flush();
+            ->getResult();
     }
 
     /**


### PR DESCRIPTION
This works around a Doctrine bug where it sees an entity as managed because it happens to reuse an object hash from an earlier created and destroyed object.