### PR TITLE
Don't add RaCandidate if identity is already an RA

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
@@ -30,6 +30,7 @@ use Surfnet\Stepup\Identity\Event\VettedSecondFactorRevokedEvent;
 use Surfnet\Stepup\Identity\Event\YubikeySecondFactorBootstrappedEvent;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaCandidate;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaCandidateRepository;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaListingRepository;
 
 class RaCandidateProjector extends Projector
 {
@@ -38,9 +39,15 @@ class RaCandidateProjector extends Projector
      */
     private $raCandidateRepository;
 
-    public function __construct(RaCandidateRepository $raCandidateRepository)
+    /**
+     * @var RaListingRepository
+     */
+    private $raListingRepository;
+
+    public function __construct(RaCandidateRepository $raCandidateRepository, RaListingRepository $raListingRepository)
     {
         $this->raCandidateRepository = $raCandidateRepository;
+        $this->raListingRepository = $raListingRepository;
     }
 
     /**
@@ -49,6 +56,10 @@ class RaCandidateProjector extends Projector
      */
     public function applySecondFactorVettedEvent(SecondFactorVettedEvent $event)
     {
+        if ($this->raListingRepository->findByIdentityId($event->identityId)) {
+            return;
+        }
+
         $candidate = RaCandidate::nominate(
             $event->identityId,
             $event->identityInstitution,

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/projection.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/projection.yml
@@ -18,6 +18,7 @@ services:
             - @surfnet_stepup_middleware_api.repository.verified_second_factor
             - @surfnet_stepup_middleware_api.repository.vetted_second_factor
             - @surfnet_stepup_middleware_api.repository.identity
+            - @doctrine.orm.middleware_entity_manager
         tags: [{ name: event_bus.event_listener }]
 
     surfnet_stepup_middleware_api.projector.ra_second_factor:
@@ -38,6 +39,7 @@ services:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Projector\RaCandidateProjector
         arguments:
             - @surfnet_stepup_middleware_api.repository.ra_candidate
+            - @surfnet_stepup_middleware_api.repository.ra_listing
         tags: [{ name: event_bus.event_listener }]
 
     surfnet_stepup_middleware_api.projector.sraa:

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/projection.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/projection.yml
@@ -18,7 +18,6 @@ services:
             - @surfnet_stepup_middleware_api.repository.verified_second_factor
             - @surfnet_stepup_middleware_api.repository.vetted_second_factor
             - @surfnet_stepup_middleware_api.repository.identity
-            - @doctrine.orm.middleware_entity_manager
         tags: [{ name: event_bus.event_listener }]
 
     surfnet_stepup_middleware_api.projector.ra_second_factor:


### PR DESCRIPTION
An RA may choose to couple a new SF, this may not lead to a new candidacy.

@pmeulen do you agree with this solution?