### PR TITLE
Invert the way RA locations are configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The configuration must be a json object with the following keys:
 * sraa
 * email_templates
 * gateway
+* institutions_with_ra_locations
 Each of these keys will be described in detail in a section below. The minimum structure the configuration must have is therefore:
 ```json
 {
@@ -53,7 +54,7 @@ Each of these keys will be described in detail in a section below. The minimum s
         "identity_providers": [],
         "service_providers": []
     },
-    "institutions_with_personal_ra_details": []
+    "institutions_with_ra_locations": []
 }
 ```
 
@@ -135,7 +136,7 @@ As a full example:
             }
         ]
     },
-    "institutions_with_personal_ra_details": []
+    "institutions_with_ra_locations": []
 }
 ```
 

--- a/app/DoctrineMigrations/Version20160622160146.php
+++ b/app/DoctrineMigrations/Version20160622160146.php
@@ -19,7 +19,7 @@ class Version20160622160146 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('CREATE TABLE institution_with_ra_locations (institution VARCHAR(255) NOT NULL, PRIMARY KEY(institution)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
-        $this->addSql('DROP TABLE institution_with_ra_locations');
+        $this->addSql('DROP TABLE institution_with_personal_ra_details');
     }
 
     /**
@@ -31,6 +31,6 @@ class Version20160622160146 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('CREATE TABLE institution_with_ra_locations (institution VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci, PRIMARY KEY(institution)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
-        $this->addSql('DROP TABLE institution_with_ra_locations');
+        $this->addSql('DROP TABLE institution_with_personal_ra_details');
     }
 }

--- a/app/DoctrineMigrations/Version20160622160146.php
+++ b/app/DoctrineMigrations/Version20160622160146.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Surfnet\StepupMiddleware\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160622160146 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE institution_with_ra_locations (institution VARCHAR(255) NOT NULL, PRIMARY KEY(institution)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('DROP TABLE institution_with_ra_locations');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE institution_with_ra_locations (institution VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci, PRIMARY KEY(institution)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('DROP TABLE institution_with_ra_locations');
+    }
+}

--- a/app/DoctrineMigrations/Version20160622160146.php
+++ b/app/DoctrineMigrations/Version20160622160146.php
@@ -30,7 +30,7 @@ class Version20160622160146 extends AbstractMigration
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('CREATE TABLE institution_with_ra_locations (institution VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci, PRIMARY KEY(institution)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
-        $this->addSql('DROP TABLE institution_with_personal_ra_details');
+        $this->addSql('CREATE TABLE institution_with_personal_ra_details (institution VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci, PRIMARY KEY(institution)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('DROP TABLE institution_with_ra_locations');
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Configuration.php
+++ b/src/Surfnet/Stepup/Configuration/Configuration.php
@@ -24,7 +24,7 @@ use Surfnet\Stepup\Configuration\Api\Configuration as ConfigurationInterface;
 use Surfnet\Stepup\Configuration\Event\ConfigurationUpdatedEvent;
 use Surfnet\Stepup\Configuration\Event\EmailTemplatesUpdatedEvent;
 use Surfnet\Stepup\Configuration\Event\IdentityProvidersUpdatedEvent;
-use Surfnet\Stepup\Configuration\Event\InstitutionsWithPersonalRaDetailsUpdatedEvent;
+use Surfnet\Stepup\Configuration\Event\InstitutionsWithRaLocationsUpdatedEvent;
 use Surfnet\Stepup\Configuration\Event\NewConfigurationCreatedEvent;
 use Surfnet\Stepup\Configuration\Event\ServiceProvidersUpdatedEvent;
 use Surfnet\Stepup\Configuration\Event\SraaUpdatedEvent;
@@ -69,9 +69,9 @@ class Configuration extends EventSourcedAggregateRoot implements ConfigurationIn
         ));
         $this->apply(new SraaUpdatedEvent(self::CONFIGURATION_ID, $decodedConfiguration['sraa']));
         $this->apply(new EmailTemplatesUpdatedEvent(self::CONFIGURATION_ID, $decodedConfiguration['email_templates']));
-        $this->apply(new InstitutionsWithPersonalRaDetailsUpdatedEvent(
+        $this->apply(new InstitutionsWithRaLocationsUpdatedEvent(
             self::CONFIGURATION_ID,
-            $decodedConfiguration['institutions_with_personal_ra_details']
+            $decodedConfiguration['institutions_with_ra_locations']
         ));
     }
 

--- a/src/Surfnet/Stepup/Configuration/Event/InstitutionsWithRaLocationsUpdatedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/InstitutionsWithRaLocationsUpdatedEvent.php
@@ -18,34 +18,34 @@
 
 namespace Surfnet\Stepup\Configuration\Event;
 
-final class InstitutionsWithPersonalRaDetailsUpdatedEvent extends ConfigurationEvent
+final class InstitutionsWithRaLocationsUpdatedEvent extends ConfigurationEvent
 {
     /**
      * @var string[]
      */
-    public $institutionsWithPersonalRaDetails;
+    public $institutionsWithRaLocations;
 
     /**
      * @param string $configurationId
-     * @param string[] $institutionsWithPersonalRaDetails
+     * @param string[] $institutionsWithRaLocations
      */
-    public function __construct($configurationId, array $institutionsWithPersonalRaDetails)
+    public function __construct($configurationId, array $institutionsWithRaLocations)
     {
         parent::__construct($configurationId);
 
-        $this->institutionsWithPersonalRaDetails = $institutionsWithPersonalRaDetails;
+        $this->institutionsWithRaLocations = $institutionsWithRaLocations;
     }
 
     public static function deserialize(array $data)
     {
-        return new self($data['id'], $data['institutions_with_personal_ra_details']);
+        return new self($data['id'], $data['institutions_with_ra_locations']);
     }
 
     public function serialize()
     {
         return [
             'id'                                    => $this->id,
-            'institutions_with_personal_ra_details' => $this->institutionsWithPersonalRaDetails,
+            'institutions_with_ra_locations' => $this->institutionsWithRaLocations,
         ];
     }
 }

--- a/src/Surfnet/Stepup/Tests/Configuration/Event/EventSerializationAndDeserializationTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Event/EventSerializationAndDeserializationTest.php
@@ -25,7 +25,7 @@ use Surfnet\Stepup\Configuration\Configuration;
 use Surfnet\Stepup\Configuration\Event\ConfigurationUpdatedEvent;
 use Surfnet\Stepup\Configuration\Event\EmailTemplatesUpdatedEvent;
 use Surfnet\Stepup\Configuration\Event\IdentityProvidersUpdatedEvent;
-use Surfnet\Stepup\Configuration\Event\InstitutionsWithPersonalRaDetailsUpdatedEvent;
+use Surfnet\Stepup\Configuration\Event\InstitutionsWithRaLocationsUpdatedEvent;
 use Surfnet\Stepup\Configuration\Event\NewConfigurationCreatedEvent;
 use Surfnet\Stepup\Configuration\Event\NewInstitutionConfigurationCreatedEvent;
 use Surfnet\Stepup\Configuration\Event\RaLocationAddedEvent;
@@ -105,8 +105,8 @@ class EventSerializationAndDeserializationTest extends TestCase
                     ['sraa']
                 )
             ],
-            'InstitutionsWithPersonalRaDetailsUpdatedEvent' => [
-                new InstitutionsWithPersonalRaDetailsUpdatedEvent(
+            'InstitutionsWithRaLocationsUpdatedEvent' => [
+                new InstitutionsWithRaLocationsUpdatedEvent(
                     Configuration::CONFIGURATION_ID,
                     ['some.institution.test']
                 )

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/InstitutionWithRaLocations.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/InstitutionWithRaLocations.php
@@ -24,10 +24,10 @@ use Surfnet\Stepup\Configuration\Value\Institution;
 
 /**
  * @ORM\Entity(
- *      repositoryClass="Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionWithPersonalRaDetailsRepository"
+ *      repositoryClass="Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionWithRaLocationsRepository"
  * )
  */
-class InstitutionWithPersonalRaDetails implements JsonSerializable
+class InstitutionWithRaLocations implements JsonSerializable
 {
     /**
      * @ORM\Id
@@ -39,15 +39,15 @@ class InstitutionWithPersonalRaDetails implements JsonSerializable
 
     /**
      * @param Institution $institution
-     * @return InstitutionWithPersonalRaDetails
+     * @return InstitutionWithRaLocations
      */
     public static function createFrom(Institution $institution)
     {
-        $institutionWithPersonalRaDetails = new self;
+        $institutionWithRaLocations = new self;
 
-        $institutionWithPersonalRaDetails->institution = $institution;
+        $institutionWithRaLocations->institution = $institution;
 
-        return $institutionWithPersonalRaDetails;
+        return $institutionWithRaLocations;
     }
 
     public function jsonSerialize()

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Projector/InstitutionWithRaLocationsProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Projector/InstitutionWithRaLocationsProjector.php
@@ -19,28 +19,28 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Configuration\Projector;
 
 use Broadway\ReadModel\Projector;
-use Surfnet\Stepup\Configuration\Event\InstitutionsWithPersonalRaDetailsUpdatedEvent;
+use Surfnet\Stepup\Configuration\Event\InstitutionsWithRaLocationsUpdatedEvent;
 use Surfnet\Stepup\Configuration\Value\Institution;
-use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionWithPersonalRaDetails;
-use Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionWithPersonalRaDetailsRepository;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionWithRaLocations;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionWithRaLocationsRepository;
 
-final class InstitutionWithPersonalRaDetailsProjector extends Projector
+final class InstitutionWithRaLocationsProjector extends Projector
 {
     /**
-     * @var InstitutionWithPersonalRaDetails
+     * @var InstitutionWithRaLocations
      */
     private $repository;
 
-    public function __construct(InstitutionWithPersonalRaDetailsRepository $repository)
+    public function __construct(InstitutionWithRaLocationsRepository $repository)
     {
         $this->repository = $repository;
     }
 
-    public function applyInstitutionsWithPersonalRaDetailsUpdatedEvent(
-        InstitutionsWithPersonalRaDetailsUpdatedEvent $event
+    public function applyInstitutionsWithRaLocationsUpdatedEvent(
+        InstitutionsWithRaLocationsUpdatedEvent $event
     ) {
-        foreach ($event->institutionsWithPersonalRaDetails as $institution) {
-            $this->repository->addIfNotExists(InstitutionWithPersonalRaDetails::createFrom(new Institution($institution)));
+        foreach ($event->institutionsWithRaLocations as $institution) {
+            $this->repository->addIfNotExists(InstitutionWithRaLocations::createFrom(new Institution($institution)));
         }
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Repository/InstitutionWithRaLocationsRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Repository/InstitutionWithRaLocationsRepository.php
@@ -20,19 +20,18 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository;
 
 use Doctrine\ORM\EntityRepository;
 use Surfnet\Stepup\Configuration\Value\Institution;
-use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionWithPersonalRaDetails;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionWithRaLocations;
 
-final class InstitutionWithPersonalRaDetailsRepository extends EntityRepository
+final class InstitutionWithRaLocationsRepository extends EntityRepository
 {
     /**
-     * @param InstitutionWithPersonalRaDetails $institutionWithPersonalRaDetails
+     * @param InstitutionWithRaLocations $institutionWithRaLocations
      */
-    public function addIfNotExists(
-        InstitutionWithPersonalRaDetails $institutionWithPersonalRaDetails
-    ) {
+    public function addIfNotExists(InstitutionWithRaLocations $institutionWithRaLocations)
+    {
         $existsQuery = $this->createQueryBuilder('ipr')
             ->where('ipr.institution = :institution')
-            ->setParameter('institution', $institutionWithPersonalRaDetails->institution)
+            ->setParameter('institution', $institutionWithRaLocations->institution)
             ->getQuery()
             ->getOneOrNullResult();
 
@@ -41,18 +40,18 @@ final class InstitutionWithPersonalRaDetailsRepository extends EntityRepository
         }
 
         $em = $this->getEntityManager();
-        $em->persist($institutionWithPersonalRaDetails);
-        $em->flush($institutionWithPersonalRaDetails);
+        $em->persist($institutionWithRaLocations);
+        $em->flush($institutionWithRaLocations);
     }
 
     /**
      * @param Institution $institution
      * @return boolean
      */
-    public function institutionHasPersonalRaDetails(Institution $institution)
+    public function institutionShowsRaLocations(Institution $institution)
     {
-        $matchedInstitutions = $this->createQueryBuilder('ipr')
-            ->where('ipr.institution = :institution')
+        $matchedInstitutions = $this->createQueryBuilder('irl')
+            ->where('irl.institution = :institution')
             ->setParameter('institution', $institution->getInstitution())
             ->getQuery()
             ->getArrayResult();

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Service/InstitutionWithRaLocationsService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Service/InstitutionWithRaLocationsService.php
@@ -19,17 +19,17 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Configuration\Service;
 
 use Surfnet\Stepup\Configuration\Value\Institution;
-use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionWithPersonalRaDetails;
-use Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionWithPersonalRaDetailsRepository;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionWithRaLocations;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionWithRaLocationsRepository;
 
-class InstitutionWithPersonalRaDetailsService
+class InstitutionWithRaLocationsService
 {
     /**
-     * @var InstitutionWithPersonalRaDetailsRepository
+     * @var InstitutionWithRaLocationsRepository
      */
     private $repository;
 
-    public function __construct(InstitutionWithPersonalRaDetailsRepository $repository)
+    public function __construct(InstitutionWithRaLocationsRepository $repository)
     {
         $this->repository = $repository;
     }
@@ -38,13 +38,13 @@ class InstitutionWithPersonalRaDetailsService
      * @param Institution $institution
      * @return boolean
      */
-    public function institutionHasPersonalRaDetails(Institution $institution)
+    public function institutionShowsRaLocations(Institution $institution)
     {
-        return $this->repository->institutionHasPersonalRaDetails($institution);
+        return $this->repository->institutionShowsRaLocations($institution);
     }
 
     /**
-     * @return InstitutionWithPersonalRaDetails[]
+     * @return InstitutionWithRaLocations[]
      */
     public function findAll()
     {

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionWithRaLocationsController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionWithRaLocationsController.php
@@ -30,9 +30,9 @@ final class InstitutionWithRaLocationsController extends Controller
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
 
-        $personalRaDetailsEnabled = $this->getService()->institutionShowsRaLocations($institution);
+        $institutionShowsRaLocations = $this->getService()->institutionShowsRaLocations($institution);
 
-        return new JsonResponse($personalRaDetailsEnabled);
+        return new JsonResponse($institutionShowsRaLocations);
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionWithRaLocationsController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionWithRaLocationsController.php
@@ -19,27 +19,27 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
 use Surfnet\Stepup\Configuration\Value\Institution;
-use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionWithPersonalRaDetailsService;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionWithRaLocationsService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-final class InstitutionWithPersonalRaDetailsController extends Controller
+final class InstitutionWithRaLocationsController extends Controller
 {
-    public function hasPersonalRaDetailsAction(Request $request, Institution $institution)
+    public function showsRaLocationsAction(Request $request, Institution $institution)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
 
-        $personalRaDetailsEnabled = $this->getService()->institutionHasPersonalRaDetails($institution);
+        $personalRaDetailsEnabled = $this->getService()->institutionShowsRaLocations($institution);
 
         return new JsonResponse($personalRaDetailsEnabled);
     }
 
     /**
-     * @return InstitutionWithPersonalRaDetailsService
+     * @return InstitutionWithRaLocationsService
      */
     private function getService()
     {
-        return $this->container->get('surfnet_stepup_middleware_api.service.institution_with_personal_ra_details');
+        return $this->container->get('surfnet_stepup_middleware_api.service.institution_with_ra_locations');
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/projection.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/projection.yml
@@ -72,8 +72,8 @@ services:
             - @surfnet_stepup_middleware_api.repository.ra_location
         tags: [{ name: event_bus.event_listener }]
 
-    surfnet_stepup_middleware_api.projector.institution_with_personal_ra_details:
-        class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Projector\InstitutionWithPersonalRaDetailsProjector
+    surfnet_stepup_middleware_api.projector.institution_with_ra_locations:
+        class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Projector\InstitutionWithRaLocationsProjector
         arguments:
-            - @surfnet_stepup_middleware_api.repository.institution_with_personal_ra_details
+            - @surfnet_stepup_middleware_api.repository.institution_with_ra_locations
         tags: [{ name: event_bus.event_listener }]

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
@@ -110,9 +110,9 @@ institution_listing:
     methods:   [GET]
     condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
 
-institution_has_personal_ra_locations:
-    path: /has-personal-ra-locations/{institution}
-    defaults: { _controller: SurfnetStepupMiddlewareApiBundle:InstitutionWithPersonalRaDetails:hasPersonalRaDetails }
+institution_shows_ra_locations:
+    path: /shows-personal-ra-locations/{institution}
+    defaults: { _controller: SurfnetStepupMiddlewareApiBundle:InstitutionWithRaLocations:showsRaLocations }
     methods: [GET]
     condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
@@ -111,7 +111,7 @@ institution_listing:
     condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
 
 institution_shows_ra_locations:
-    path: /shows-personal-ra-locations/{institution}
+    path: /shows-ra-locations/{institution}
     defaults: { _controller: SurfnetStepupMiddlewareApiBundle:InstitutionWithRaLocations:showsRaLocations }
     methods: [GET]
     condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
@@ -15,10 +15,10 @@ services:
         factory: [@doctrine.orm.middleware_entity_manager, getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\InstitutionListing ]
 
-    surfnet_stepup_middleware_api.repository.institution_with_personal_ra_details:
-        class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionWithPersonalRaDetailsRepository
+    surfnet_stepup_middleware_api.repository.institution_with_ra_locations:
+        class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionWithRaLocationsRepository
         factory: [@doctrine.orm.middleware_entity_manager, getRepository]
-        arguments: [ Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionWithPersonalRaDetails ]
+        arguments: [ Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionWithRaLocations ]
 
     surfnet_stepup_middleware_api.repository.ra_candidate:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaCandidateRepository
@@ -94,10 +94,10 @@ services:
         arguments:
             - @surfnet_stepup_middleware_api.repository.institution_listing
 
-    surfnet_stepup_middleware_api.service.institution_with_personal_ra_details:
-        class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionWithPersonalRaDetailsService
+    surfnet_stepup_middleware_api.service.institution_with_ra_locations:
+        class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionWithRaLocationsService
         arguments:
-            - @surfnet_stepup_middleware_api.repository.institution_with_personal_ra_details
+            - @surfnet_stepup_middleware_api.repository.institution_with_ra_locations
 
     surfnet_stepup_middleware_api.service.ra_candidate:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaCandidateService
@@ -185,6 +185,6 @@ services:
     surfnet_stepup_middleware_api.service.vetting_location:
         class: Surfnet\StepupMiddleware\ApiBundle\Service\VettingLocationService
         arguments:
-            - '@surfnet_stepup_middleware_api.service.institution_with_personal_ra_details'
+            - '@surfnet_stepup_middleware_api.service.institution_with_ra_locations'
             - '@surfnet_stepup_middleware_api.service.ra_location'
             - '@surfnet_stepup_middleware_api.service.ra_listing'

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Service/VettingLocationService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Service/VettingLocationService.php
@@ -21,7 +21,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Service;
 use Surfnet\Stepup\Configuration\Value\Institution as ConfigurationInstitution;
 use Surfnet\Stepup\Identity\Value\Institution as IdentityInstitution;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\RaLocation;
-use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionWithPersonalRaDetailsService;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionWithRaLocationsService;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\RaLocationService;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaListingService;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RegistrationAuthorityCredentials;
@@ -32,7 +32,7 @@ use Surfnet\StepupMiddleware\CommandHandlingBundle\Value\Institution;
 final class VettingLocationService implements VettingLocationServiceInterface
 {
     /**
-     * @var InstitutionWithPersonalRaDetailsService
+     * @var InstitutionWithRaLocationsService
      */
     private $personalRaDetailsService;
 
@@ -47,7 +47,7 @@ final class VettingLocationService implements VettingLocationServiceInterface
     private $raListingService;
 
     public function __construct(
-        InstitutionWithPersonalRaDetailsService $personalRaDetailsService,
+        InstitutionWithRaLocationsService $personalRaDetailsService,
         RaLocationService $raLocationService,
         RaListingService $raListingService
     ) {
@@ -64,7 +64,7 @@ final class VettingLocationService implements VettingLocationServiceInterface
     {
         $configurationInstitution = new ConfigurationInstitution($institution->getInstitution());
 
-        if ($this->personalRaDetailsService->institutionHasPersonalRaDetails($configurationInstitution)) {
+        if ($this->personalRaDetailsService->institutionShowsRaLocations($configurationInstitution)) {
             $identityInstitution = new IdentityInstitution($institution->getInstitution());
 
             return array_map(

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Service/VettingLocationService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Service/VettingLocationService.php
@@ -65,29 +65,29 @@ final class VettingLocationService implements VettingLocationServiceInterface
         $configurationInstitution = new ConfigurationInstitution($institution->getInstitution());
 
         if ($this->personalRaDetailsService->institutionShowsRaLocations($configurationInstitution)) {
-            $identityInstitution = new IdentityInstitution($institution->getInstitution());
-
             return array_map(
-                function (RegistrationAuthorityCredentials $credentials) {
+                function (RaLocation $raLocation) {
                     return new VettingLocation(
-                        $credentials->getCommonName()->getCommonName(),
-                        $credentials->getLocation()->getLocation(),
-                        $credentials->getContactInformation()->getContactInformation()
+                        $raLocation->name->getRaLocationName(),
+                        $raLocation->location->getLocation(),
+                        $raLocation->contactInformation->getContactInformation()
                     );
                 },
-                $this->raListingService->listRegistrationAuthoritiesFor($identityInstitution)
+                $this->raLocationService->listRaLocationsFor($configurationInstitution)
             );
         }
 
+        $identityInstitution = new IdentityInstitution($institution->getInstitution());
+
         return array_map(
-            function (RaLocation $raLocation) {
+            function (RegistrationAuthorityCredentials $credentials) {
                 return new VettingLocation(
-                    $raLocation->name->getRaLocationName(),
-                    $raLocation->location->getLocation(),
-                    $raLocation->contactInformation->getContactInformation()
+                    $credentials->getCommonName()->getCommonName(),
+                    $credentials->getLocation()->getLocation(),
+                    $credentials->getContactInformation()->getContactInformation()
                 );
             },
-            $this->raLocationService->listRaLocationsFor($configurationInstitution)
+            $this->raListingService->listRegistrationAuthoritiesFor($identityInstitution)
         );
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Service/VettingLocationService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Service/VettingLocationService.php
@@ -34,7 +34,7 @@ final class VettingLocationService implements VettingLocationServiceInterface
     /**
      * @var InstitutionWithRaLocationsService
      */
-    private $personalRaDetailsService;
+    private $institutionWithRaLocations;
 
     /**
      * @var RaLocationService
@@ -47,13 +47,13 @@ final class VettingLocationService implements VettingLocationServiceInterface
     private $raListingService;
 
     public function __construct(
-        InstitutionWithRaLocationsService $personalRaDetailsService,
+        InstitutionWithRaLocationsService $institutionWithRaLocationsService,
         RaLocationService $raLocationService,
         RaListingService $raListingService
     ) {
-        $this->personalRaDetailsService = $personalRaDetailsService;
-        $this->raLocationService        = $raLocationService;
-        $this->raListingService         = $raListingService;
+        $this->institutionWithRaLocations = $institutionWithRaLocationsService;
+        $this->raLocationService          = $raLocationService;
+        $this->raListingService           = $raListingService;
     }
 
     /**
@@ -64,7 +64,7 @@ final class VettingLocationService implements VettingLocationServiceInterface
     {
         $configurationInstitution = new ConfigurationInstitution($institution->getInstitution());
 
-        if ($this->personalRaDetailsService->institutionShowsRaLocations($configurationInstitution)) {
+        if ($this->institutionWithRaLocations->institutionShowsRaLocations($configurationInstitution)) {
             return array_map(
                 function (RaLocation $raLocation) {
                     return new VettingLocation(

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Service/VettingLocationServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Service/VettingLocationServiceTest.php
@@ -44,7 +44,7 @@ class VettingLocationServiceTest extends TestCase
      * @group api-bundle
      * @group vetting
      */
-    public function vetting_locations_can_be_determined_for_institution_with_personal_ra_details()
+    public function vetting_locations_can_be_determined_for_institution_with_ra_locations()
     {
         $expectedRaName                = 'RA';
         $expectedRaLocation            = 'Personal location';
@@ -57,8 +57,8 @@ class VettingLocationServiceTest extends TestCase
         $configurationInstitution = new ConfigurationInstitution($institutionValue);
         $identityInstitution      = new IdentityInstitution($institutionValue);
 
-        $institutionsWithPersonalRaDetailsService = m::mock(
-            'Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionWithPersonalRaDetailsService'
+        $institutionsWithRaLocationsService = m::mock(
+            'Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionWithRaLocationsService'
         );
         $raLocationsService                       = m::mock(
             'Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\RaLocationService'
@@ -67,8 +67,8 @@ class VettingLocationServiceTest extends TestCase
             '\Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaListingService'
         );
 
-        $institutionsWithPersonalRaDetailsService
-            ->shouldReceive('institutionHasPersonalRaDetails')
+        $institutionsWithRaLocationsService
+            ->shouldReceive('institutionShowsRaLocations')
             ->with(
                 m::on(
                     function (ConfigurationInstitution $actualInstitution) use ($configurationInstitution) {
@@ -120,7 +120,7 @@ class VettingLocationServiceTest extends TestCase
         ];
 
         $vettingLocationService = new VettingLocationService(
-            $institutionsWithPersonalRaDetailsService,
+            $institutionsWithRaLocationsService,
             $raLocationsService,
             $raListingService
         );
@@ -135,7 +135,7 @@ class VettingLocationServiceTest extends TestCase
      * @group api-bundle
      * @group vetting
      */
-    public function vetting_locations_can_be_determined_for_institution_with_ra_locations()
+    public function vetting_locations_can_be_determined_for_institution_without_ra_locations()
     {
         $expectedRaName                = 'RA Service Desk';
         $expectedRaLocation            = 'On site';
@@ -147,8 +147,8 @@ class VettingLocationServiceTest extends TestCase
         $institutionValue         = 'institution.test';
         $configurationInstitution = new ConfigurationInstitution($institutionValue);
 
-        $institutionsWithPersonalRaDetailsService = m::mock(
-            'Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionWithPersonalRaDetailsService'
+        $institutionsWithRaLocationsService = m::mock(
+            'Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionWithRaLocationsService'
         );
         $raLocationsService                       = m::mock(
             'Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\RaLocationService'
@@ -157,8 +157,8 @@ class VettingLocationServiceTest extends TestCase
             '\Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaListingService'
         );
 
-        $institutionsWithPersonalRaDetailsService
-            ->shouldReceive('institutionHasPersonalRaDetails')
+        $institutionsWithRaLocationsService
+            ->shouldReceive('institutionShowsRaLocations')
             ->with(
                 m::on(
                     function (ConfigurationInstitution $actualInstitution) use ($configurationInstitution) {
@@ -202,7 +202,7 @@ class VettingLocationServiceTest extends TestCase
         ];
 
         $vettingLocationService = new VettingLocationService(
-            $institutionsWithPersonalRaDetailsService,
+            $institutionsWithRaLocationsService,
             $raLocationsService,
             $raListingService
         );

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Service/VettingLocationServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Service/VettingLocationServiceTest.php
@@ -47,10 +47,10 @@ class VettingLocationServiceTest extends TestCase
     public function vetting_locations_can_be_determined_for_institution_with_ra_locations()
     {
         $expectedRaName                = 'RA';
-        $expectedRaLocation            = 'Personal location';
+        $expectedRaLocation            = 'An RA location';
         $expectedRaContactInformation  = 'RA contact information';
         $expectedRaaName               = 'RAA';
-        $expectedRaaLocation           = 'Another personal location';
+        $expectedRaaLocation           = 'An RA location';
         $expectedRaaContactInformation = 'RAA contact information';
 
         $institutionValue         = 'institution.test';
@@ -76,7 +76,7 @@ class VettingLocationServiceTest extends TestCase
                     }
                 )
             )
-            ->andReturn(true);
+            ->andReturn(false);
 
         $raListingService
             ->shouldReceive('listRegistrationAuthoritiesFor')
@@ -135,7 +135,7 @@ class VettingLocationServiceTest extends TestCase
      * @group api-bundle
      * @group vetting
      */
-    public function vetting_locations_can_be_determined_for_institution_without_ra_locations()
+    public function vetting_locations_can_be_determined_for_institution_with_personal_ra_details()
     {
         $expectedRaName                = 'RA Service Desk';
         $expectedRaLocation            = 'On site';
@@ -166,7 +166,7 @@ class VettingLocationServiceTest extends TestCase
                     }
                 )
             )
-            ->andReturn(false);
+            ->andReturn(true);
 
         $raLocationsService
             ->shouldReceive('listRaLocationsFor')

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/ConfigurationCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/ConfigurationCommandHandlerTest.php
@@ -25,7 +25,7 @@ use Surfnet\Stepup\Configuration\Configuration;
 use Surfnet\Stepup\Configuration\Event\ConfigurationUpdatedEvent;
 use Surfnet\Stepup\Configuration\Event\EmailTemplatesUpdatedEvent;
 use Surfnet\Stepup\Configuration\Event\IdentityProvidersUpdatedEvent;
-use Surfnet\Stepup\Configuration\Event\InstitutionsWithPersonalRaDetailsUpdatedEvent;
+use Surfnet\Stepup\Configuration\Event\InstitutionsWithRaLocationsUpdatedEvent;
 use Surfnet\Stepup\Configuration\Event\NewConfigurationCreatedEvent;
 use Surfnet\Stepup\Configuration\Event\ServiceProvidersUpdatedEvent;
 use Surfnet\Stepup\Configuration\Event\SraaUpdatedEvent;
@@ -57,7 +57,7 @@ final class ConfigurationCommandHandlerTest extends CommandHandlerTest
                 'confirm_email'     => ['en_GB' => ''],
                 'registration_code' => ['en_GB' => ''],
             ],
-            'institutions_with_personal_ra_details' => []
+            'institutions_with_ra_locations' => []
         ];
 
         $this->scenario
@@ -83,7 +83,7 @@ final class ConfigurationCommandHandlerTest extends CommandHandlerTest
                 'confirm_email'     => ['en_GB' => ''],
                 'registration_code' => ['en_GB' => ''],
             ],
-            'institutions_with_personal_ra_details' => []
+            'institutions_with_ra_locations' => []
         ];
 
         $configuration2 = [
@@ -120,7 +120,7 @@ final class ConfigurationCommandHandlerTest extends CommandHandlerTest
                 'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
                 'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
             ],
-            'institutions_with_personal_ra_details' => []
+            'institutions_with_ra_locations' => []
         ];
 
         $this->scenario
@@ -175,9 +175,9 @@ final class ConfigurationCommandHandlerTest extends CommandHandlerTest
             new IdentityProvidersUpdatedEvent(self::CID, $newConfiguration['gateway']['identity_providers']),
             new SraaUpdatedEvent(self::CID, $newConfiguration['sraa']),
             new EmailTemplatesUpdatedEvent(self::CID, $newConfiguration['email_templates']),
-            new InstitutionsWithPersonalRaDetailsUpdatedEvent(
+            new InstitutionsWithRaLocationsUpdatedEvent(
                 self::CID,
-                $newConfiguration['institutions_with_personal_ra_details']
+                $newConfiguration['institutions_with_ra_locations']
             ),
         ];
     }

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/empty_idp_loas.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/empty_idp_loas.php
@@ -46,6 +46,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/empty_sp_acs.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/empty_sp_acs.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/empty_sp_loas.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/empty_sp_loas.php
@@ -39,6 +39,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_blacklisted_encryption_algorithm.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_blacklisted_encryption_algorithm.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_blacklisted_encryption_algorithms.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_blacklisted_encryption_algorithms.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_email_template_locale.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_email_template_locale.php
@@ -42,6 +42,6 @@ return [
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
             'vetted'            => ['en_GB' => 'Vetted {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idp.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idp.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idp_entity_id.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idp_entity_id.php
@@ -48,6 +48,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idp_loa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idp_loa.php
@@ -48,6 +48,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idps.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_idps.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp.php
@@ -28,6 +28,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_acs.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_acs.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_assertion_encryption_enabled.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_assertion_encryption_enabled.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_entity_id.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_entity_id.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_loa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_loa.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_public_key.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_public_key.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_second_factor_only.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_second_factor_only.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_second_factor_only_nameid_patterns.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_second_factor_only_nameid_patterns.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sps.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sps.php
@@ -28,6 +28,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sraa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sraa.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sraas.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sraas.php
@@ -41,6 +41,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_email_template_confirm_email.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_email_template_confirm_email.php
@@ -40,6 +40,6 @@ return [
         'email_templates' => [
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_email_template_locale.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_email_template_locale.php
@@ -43,6 +43,6 @@ return [
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
             'vetted'            => ['en_GB' => 'Vetted {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_email_template_registration_code.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_email_template_registration_code.php
@@ -40,6 +40,6 @@ return [
         'email_templates' => [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_sps.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/missing_sps.php
@@ -27,6 +27,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_email_templates.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_email_templates.php
@@ -22,5 +22,5 @@ return [
         'gateway' => [],
         'sraa'    => [],
     ],
-    'institutions_with_personal_ra_details' => ['institution.test'],
+    'institutions_with_ra_locations' => ['institution.test'],
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_acs.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_acs.php
@@ -40,6 +40,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_assertion_encryption_enabled.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_assertion_encryption_enabled.php
@@ -40,6 +40,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_blacklisted_encryption_algorithms.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_blacklisted_encryption_algorithms.php
@@ -40,6 +40,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_entity_id.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_entity_id.php
@@ -40,6 +40,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_loas.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_loas.php
@@ -38,6 +38,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_public_key.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sp_public_key.php
@@ -40,6 +40,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sps.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sps.php
@@ -28,6 +28,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sraa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_sraa.php
@@ -20,6 +20,6 @@ return [
     'expectedPropertyPath' => '(root)',
     'configuration'        => [
         'gateway' => [],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_email_template.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_email_template.php
@@ -42,6 +42,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_gateway.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_gateway.php
@@ -42,6 +42,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_gateway_sp.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_gateway_sp.php
@@ -42,6 +42,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_root.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/no_superfluous_keys_root.php
@@ -42,6 +42,6 @@ return [
             'confirm_email'     => ['en_GB' => 'Verify {{ commonName }}'],
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_array_email_templates.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_array_email_templates.php
@@ -38,6 +38,6 @@ return [
         ],
         'sraa'            => [],
         'email_templates' => null,
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_array_gateway.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_array_gateway.php
@@ -22,6 +22,6 @@ return [
         'gateway'         => null,
         'sraa'            => [],
         'email_templates' => [],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_array_institutions_with_personal_ra_details.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_array_institutions_with_personal_ra_details.php
@@ -17,7 +17,7 @@
  */
 
 return [
-    'expectedPropertyPath' => 'institutions_with_personal_ra_details',
+    'expectedPropertyPath' => 'institutions_with_ra_locations',
     'configuration'        => [
         'gateway'         => [
             'identity_providers' => [],
@@ -42,6 +42,6 @@ return [
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
             'vetted'            => ['en_GB' => 'Vetted {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => [1],
+        'institutions_with_ra_locations' => [1],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_array_sraa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_array_sraa.php
@@ -38,6 +38,6 @@ return [
         ],
         'sraa'            => null,
         'email_templates' => [],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_strings_institutions_with_personal_ra_details.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_strings_institutions_with_personal_ra_details.php
@@ -17,7 +17,7 @@
  */
 
 return [
-    'expectedPropertyPath' => 'institutions_with_personal_ra_details',
+    'expectedPropertyPath' => 'institutions_with_ra_locations',
     'configuration'        => [
         'gateway'         => [
             'identity_providers' => [],
@@ -42,6 +42,6 @@ return [
             'registration_code' => ['en_GB' => 'Code {{ commonName }}'],
             'vetted'            => ['en_GB' => 'Vetted {{ commonName }}'],
         ],
-        'institutions_with_personal_ra_details' => null,
+        'institutions_with_ra_locations' => null,
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_strings_sraa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/not_strings_sraa.php
@@ -40,6 +40,6 @@ return [
             9
         ],
         'email_templates' => [],
-        'institutions_with_personal_ra_details' => ['institution.test'],
+        'institutions_with_ra_locations' => ['institution.test'],
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ConfigurationStructureValidator.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ConfigurationStructureValidator.php
@@ -81,7 +81,7 @@ class ConfigurationStructureValidator extends ConstraintValidator
     {
         Assert::isArray($configuration, 'Invalid body structure, must be an object', '(root)');
 
-        $acceptedProperties = ['gateway', 'sraa', 'email_templates', 'institutions_with_personal_ra_details'];
+        $acceptedProperties = ['gateway', 'sraa', 'email_templates', 'institutions_with_ra_locations'];
         StepupAssert::keysMatch(
             $configuration,
             $acceptedProperties,
@@ -92,9 +92,9 @@ class ConfigurationStructureValidator extends ConstraintValidator
         $this->validateGatewayConfiguration($configuration, 'gateway');
         $this->validateSraaConfiguration($configuration, 'sraa');
         $this->validateEmailTemplatesConfiguration($configuration, 'email_templates');
-        $this->validateInstitutionsWithPersonalRaDetailsConfiguration(
+        $this->validateInstitutionsWithRaLocationsConfiguration(
             $configuration,
-            'institutions_with_personal_ra_details'
+            'institutions_with_ra_locations'
         );
     }
 
@@ -133,7 +133,7 @@ class ConfigurationStructureValidator extends ConstraintValidator
         $this->emailTemplatesConfigurationValidator->validate($configuration['email_templates'], $propertyPath);
     }
 
-    private function validateInstitutionsWithPersonalRaDetailsConfiguration($configuration, $propertyPath)
+    private function validateInstitutionsWithRaLocationsConfiguration($configuration, $propertyPath)
     {
         Assert::isArray(
             $configuration[$propertyPath],


### PR DESCRIPTION
Instead of configuring which institutions should show personal RA details, it can now be configured which institutions want to specify RA locations to show.

Naming has been adjusted to this practice.