### PR TITLE
Fix vetting locations and email templates

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -44,12 +44,12 @@ services:
         arguments:
             - [ if, else, elseif, for ] # Allowed tags
             - [ escape ] # Allowed filters
-            - # Allowed methods
-                Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RegistrationAuthorityCredentials:
-                    - getCommonName
-                    - getLocation
-                    - getContactInformation
-            - [] # Allowed properties
+            - [] # Allowed methods
+            - # Allowed properties
+                Surfnet\StepupMiddleware\CommandHandlingBundle\Dto\VettingLocation:
+                    - name
+                    - location
+                    - contactInformation
             - [] # Allowed functions
 
 # Doctrine Configuration

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Repository/RaLocationRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Repository/RaLocationRepository.php
@@ -93,6 +93,6 @@ class RaLocationRepository extends EntityRepository
             ->where('rl.institution = :institution')
             ->setParameter('institution', $institution->getInstitution())
             ->getQuery()
-            ->getArrayResult();
+            ->getResult();
     }
 }


### PR DESCRIPTION
Note that the concept of a VettingLocation will have to go in the near future, as RaLocations and RegistrationAuthorityCredentials are clearly distinguishable concepts that do not need to be unified in this manner.