### PR TITLE
Expand tables for event replays

### DIFF
--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/EventStreamReplayer.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/EventStreamReplayer.php
@@ -50,6 +50,8 @@ class EventStreamReplayer
         'unverified_second_factor',
         'verified_second_factor',
         'vetted_second_factor',
+        'configured_institution',
+        'ra_location',
         'ra_second_factor',
         'identity',
         'sraa',

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/EventStreamReplayer.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/EventStreamReplayer.php
@@ -44,7 +44,7 @@ class EventStreamReplayer
     private $connectionHelper;
 
     /**
-     * @var array
+     * @var string[]
      */
     private $middlewareTables = [
         'unverified_second_factor',
@@ -63,7 +63,7 @@ class EventStreamReplayer
     ];
 
     /**
-     * @var array
+     * @var string[]
      */
     private $gatewayTables = [
         'second_factor',


### PR DESCRIPTION
I found out my event replays were consistently failing, because projection tables were not cleared automatically. This adds the tables to the EventStreamReplayer, causing them to be cleared properly before replaying.