### PR TITLE
Show institution configuration options

### DIFF
--- a/src/Surfnet/Stepup/Configuration/Value/UseRaLocationsOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/UseRaLocationsOption.php
@@ -18,9 +18,10 @@
 
 namespace Surfnet\Stepup\Configuration\Value;
 
+use JsonSerializable;
 use Surfnet\Stepup\Exception\InvalidArgumentException;
 
-final class UseRaLocationsOption
+final class UseRaLocationsOption implements JsonSerializable
 {
     /**
      * @var bool

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/InstitutionConfigurationOptions.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/InstitutionConfigurationOptions.php
@@ -69,10 +69,12 @@ final class InstitutionConfigurationOptions implements JsonSerializable
 
     public function jsonSerialize()
     {
-        return [
-            'institution' => $this->institution,
-            'use_ra_locations' => $this->useRaLocationsOption,
-            'show_raa_contact_information' => $this->showRaaContactInformationOption,
-        ];
+        return
+            [
+                $this->institution->getInstitution() => [
+                    'use_ra_locations'             => $this->useRaLocationsOption,
+                    'show_raa_contact_information' => $this->showRaaContactInformationOption,
+                ],
+            ];
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/AuthorityRoleType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/AuthorityRoleType.php
@@ -59,10 +59,9 @@ class AuthorityRoleType extends Type
             $authorityRole = new AuthorityRole($value);
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/CommonNameType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/CommonNameType.php
@@ -55,10 +55,9 @@ class CommonNameType extends Type
             $commonName = new CommonName($value);
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ConfigurationContactInformationType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ConfigurationContactInformationType.php
@@ -65,10 +65,9 @@ class ConfigurationContactInformationType extends Type
             $contactInformation = new ContactInformation($value);
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ConfigurationInstitutionType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ConfigurationInstitutionType.php
@@ -65,10 +65,9 @@ class ConfigurationInstitutionType extends Type
             $institution = new Institution($value);
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ConfigurationLocationType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ConfigurationLocationType.php
@@ -65,10 +65,9 @@ class ConfigurationLocationType extends Type
             $location = new Location($value);
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ContactInformationType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ContactInformationType.php
@@ -55,10 +55,9 @@ class ContactInformationType extends Type
             $contactInformation = new ContactInformation($value);
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/EmailType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/EmailType.php
@@ -55,10 +55,9 @@ class EmailType extends Type
             $email = new Email($value);
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/InstitutionType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/InstitutionType.php
@@ -55,10 +55,9 @@ class InstitutionType extends Type
             $institution = new Institution($value);
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/LocaleType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/LocaleType.php
@@ -55,10 +55,9 @@ class LocaleType extends Type
             $locale = new Locale($value);
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/LocationType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/LocationType.php
@@ -55,10 +55,9 @@ class LocationType extends Type
             $location = new Location($value);
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/NameIdType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/NameIdType.php
@@ -55,10 +55,9 @@ class NameIdType extends Type
             $nameId = new NameId($value);
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/RaLocationNameType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/RaLocationNameType.php
@@ -65,10 +65,9 @@ class RaLocationNameType extends Type
             $raLocationName = new RaLocationName($value);
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ShowRaaContactInformationOptionType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ShowRaaContactInformationOptionType.php
@@ -61,8 +61,17 @@ class ShowRaaContactInformationOptionType extends Type
             return $value;
         }
 
+        // Prevent a too lenient boolean conversion on non-postgresql platforms
+        if ($platform->getName() !== 'postgresql') {
+            if ($value !== 1 && $value !== 0 && $value !== '1' && $value !== '0' && !is_bool($value)) {
+                throw ConversionException::conversionFailed($value, $this->getName());
+            }
+        }
+
         try {
-            $showRaaContactInformationOption = new ShowRaaContactInformationOption($value);
+            $showRaaContactInformationOption = new ShowRaaContactInformationOption(
+                $platform->convertFromBoolean($value)
+            );
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
             $doctrineExceptionMessage = ConversionException::conversionFailedFormat(

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ShowRaaContactInformationOptionType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ShowRaaContactInformationOptionType.php
@@ -61,13 +61,6 @@ class ShowRaaContactInformationOptionType extends Type
             return $value;
         }
 
-        // Prevent a too lenient boolean conversion on non-postgresql platforms
-        if ($platform->getName() !== 'postgresql') {
-            if ($value !== 1 && $value !== 0 && $value !== '1' && $value !== '0' && !is_bool($value)) {
-                throw ConversionException::conversionFailed($value, $this->getName());
-            }
-        }
-
         try {
             $showRaaContactInformationOption = new ShowRaaContactInformationOption(
                 $platform->convertFromBoolean($value)

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ShowRaaContactInformationOptionType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/ShowRaaContactInformationOptionType.php
@@ -74,10 +74,9 @@ class ShowRaaContactInformationOptionType extends Type
             );
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/UseRaLocationsOptionType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/UseRaLocationsOptionType.php
@@ -61,8 +61,15 @@ class UseRaLocationsOptionType extends Type
             return $value;
         }
 
+        // Prevent a too lenient boolean conversion on non-postgresql platforms
+        if ($platform->getName() !== 'postgresql') {
+            if ($value !== 1 && $value !== 0 && $value !== '1' && $value !== '0' && !is_bool($value)) {
+                throw ConversionException::conversionFailed($value, $this->getName());
+            }
+        }
+
         try {
-            $useRaLocationsOption = new UseRaLocationsOption($value);
+            $useRaLocationsOption = new UseRaLocationsOption($platform->convertFromBoolean($value));
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
             $doctrineExceptionMessage = ConversionException::conversionFailedFormat(

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/UseRaLocationsOptionType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/UseRaLocationsOptionType.php
@@ -61,13 +61,6 @@ class UseRaLocationsOptionType extends Type
             return $value;
         }
 
-        // Prevent a too lenient boolean conversion on non-postgresql platforms
-        if ($platform->getName() !== 'postgresql') {
-            if ($value !== 1 && $value !== 0 && $value !== '1' && $value !== '0' && !is_bool($value)) {
-                throw ConversionException::conversionFailed($value, $this->getName());
-            }
-        }
-
         try {
             $useRaLocationsOption = new UseRaLocationsOption($platform->convertFromBoolean($value));
         } catch (InvalidArgumentException $e) {

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/UseRaLocationsOptionType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/UseRaLocationsOptionType.php
@@ -72,10 +72,9 @@ class UseRaLocationsOptionType extends Type
             $useRaLocationsOption = new UseRaLocationsOption($platform->convertFromBoolean($value));
         } catch (InvalidArgumentException $e) {
             // get nice standard message, so we can throw it keeping the exception chain
-            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
                 $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
+                $this->getName()
             )->getMessage();
 
             throw new ConversionException($doctrineExceptionMessage, 0, $e);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
@@ -81,6 +81,11 @@ services:
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\WhitelistEntry ]
 
     # Domain Services
+    surfnet_stepup_middleware_api.service.institution_configuration_options:
+        class: Surfnet\StepupMiddleware\ApiBundle\Service\InstitutionConfigurationOptionsService
+        arguments:
+            - "@surfnet_stepup_middleware_api.repository.institution_configuration_options"
+
     surfnet_stepup_middleware_api.service.configured_institutions:
         class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\ConfiguredInstitutionService
         arguments:

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
@@ -2,82 +2,82 @@ services:
     # Repositories
     surfnet_stepup_middleware_api.repository.configured_institution:
         class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\ConfiguredInstitutionRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\ConfiguredInstitution ]
 
     surfnet_stepup_middleware_api.repository.institution_configuration_options:
         class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionConfigurationOptionsRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionConfigurationOptions ]
 
     surfnet_stepup_middleware_api.repository.ra_location:
         class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\RaLocationRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\RaLocation ]
 
     surfnet_stepup_middleware_api.repository.identity:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\Identity ]
 
     surfnet_stepup_middleware_api.repository.institution_listing:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\InstitutionListingRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\InstitutionListing ]
 
     surfnet_stepup_middleware_api.repository.institution_with_ra_locations:
         class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionWithRaLocationsRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionWithRaLocations ]
 
     surfnet_stepup_middleware_api.repository.ra_candidate:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaCandidateRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaCandidate ]
 
     surfnet_stepup_middleware_api.repository.ra_listing:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaListingRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaListing ]
 
     surfnet_stepup_middleware_api.repository.sraa:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\SraaRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\Sraa ]
 
     surfnet_stepup_middleware_api.repository.unverified_second_factor:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\UnverifiedSecondFactorRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\UnverifiedSecondFactor ]
 
     surfnet_stepup_middleware_api.repository.verified_second_factor:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\VerifiedSecondFactorRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\VerifiedSecondFactor ]
 
     surfnet_stepup_middleware_api.repository.vetted_second_factor:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\VettedSecondFactorRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\VettedSecondFactor ]
 
     surfnet_stepup_middleware_api.repository.ra_second_factor:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaSecondFactorRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaSecondFactor ]
 
     surfnet_stepup_middleware_api.repository.audit_log:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\AuditLogRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\AuditLogEntry ]
 
     surfnet_stepup_middleware_api.repository.second_factor_revocation:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\SecondFactorRevocationRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\SecondFactorRevocation]
 
     surfnet_stepup_middleware_api.repository.whitelist_entry:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\WhitelistEntryRepository
-        factory: [@doctrine.orm.middleware_entity_manager, getRepository]
+        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\WhitelistEntry ]
 
     # Domain Services
@@ -94,7 +94,7 @@ services:
     surfnet_stepup_middleware_api.service.ra_location:
             class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\RaLocationService
             arguments:
-                - @surfnet_stepup_middleware_api.repository.ra_location
+                - "@surfnet_stepup_middleware_api.repository.ra_location"
 
     surfnet_stepup_middleware_api.service.abstract_search:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\AbstractSearchService
@@ -104,63 +104,63 @@ services:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\SecondFactorService
         parent: surfnet_stepup_middleware_api.service.abstract_search
         arguments:
-            - @surfnet_stepup_middleware_api.repository.unverified_second_factor
-            - @surfnet_stepup_middleware_api.repository.verified_second_factor
-            - @surfnet_stepup_middleware_api.repository.vetted_second_factor
+            - "@surfnet_stepup_middleware_api.repository.unverified_second_factor"
+            - "@surfnet_stepup_middleware_api.repository.verified_second_factor"
+            - "@surfnet_stepup_middleware_api.repository.vetted_second_factor"
 
     surfnet_stepup_middleware_api.service.institution_listing:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\InstitutionListingService
         parent: surfnet_stepup_middleware_api.service.abstract_search
         arguments:
-            - @surfnet_stepup_middleware_api.repository.institution_listing
+            - "@surfnet_stepup_middleware_api.repository.institution_listing"
 
     surfnet_stepup_middleware_api.service.institution_with_ra_locations:
         class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionWithRaLocationsService
         arguments:
-            - @surfnet_stepup_middleware_api.repository.institution_with_ra_locations
+            - "@surfnet_stepup_middleware_api.repository.institution_with_ra_locations"
 
     surfnet_stepup_middleware_api.service.ra_candidate:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaCandidateService
         parent: surfnet_stepup_middleware_api.service.abstract_search
         arguments:
-            - @surfnet_stepup_middleware_api.repository.ra_candidate
+            - "@surfnet_stepup_middleware_api.repository.ra_candidate"
 
     surfnet_stepup_middleware_api.service.ra_second_factor:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaSecondFactorService
         parent: surfnet_stepup_middleware_api.service.abstract_search
         arguments:
-            - @surfnet_stepup_middleware_api.repository.ra_second_factor
+            - "@surfnet_stepup_middleware_api.repository.ra_second_factor"
 
     surfnet_stepup_middleware_api.service.identity:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\IdentityService
         parent: surfnet_stepup_middleware_api.service.abstract_search
         arguments:
-            - @surfnet_stepup_middleware_api.repository.identity
-            - @surfnet_stepup_middleware_api.repository.ra_listing
-            - @surfnet_stepup_middleware_api.repository.sraa
+            - "@surfnet_stepup_middleware_api.repository.identity"
+            - "@surfnet_stepup_middleware_api.repository.ra_listing"
+            - "@surfnet_stepup_middleware_api.repository.sraa"
 
     surfnet_stepup_middleware_api.service.ra_listing:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaListingService
         parent: surfnet_stepup_middleware_api.service.abstract_search
         arguments:
-            - @surfnet_stepup_middleware_api.repository.ra_listing
+            - "@surfnet_stepup_middleware_api.repository.ra_listing"
 
     surfnet_stepup_middleware_api.service.sraa:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\SraaService
         parent: surfnet_stepup_middleware_api.service.abstract_search
         arguments:
-            - @surfnet_stepup_middleware_api.repository.sraa
+            - "@surfnet_stepup_middleware_api.repository.sraa"
 
     surfnet_stepup_middleware_api.service.audit_log:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\AuditLogService
         parent: surfnet_stepup_middleware_api.service.abstract_search
         arguments:
-            - @surfnet_stepup_middleware_api.repository.audit_log
+            - "@surfnet_stepup_middleware_api.repository.audit_log"
 
     surfnet_stepup_middleware_api.service.whitelist_entry:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\WhitelistService
         arguments:
-            - @surfnet_stepup_middleware_api.repository.whitelist_entry
+            - "@surfnet_stepup_middleware_api.repository.whitelist_entry"
 
     # Param Converters
     surfnet_stepup_middleware_api.request.command_param_converter:
@@ -171,7 +171,7 @@ services:
     surfnet_stepup_middleware_api.request.metadata_param_converter:
         class: Surfnet\StepupMiddleware\ApiBundle\Request\MetadataParamConverter
         arguments:
-            - @validator
+            - "@validator"
         tags:
             - { name: request.param_converter, priority: -15, converter: surfnet_stepup_middleware_api.metadata }
 
@@ -191,7 +191,7 @@ services:
     surfnet_stepup_middleware_api.listener.exception_listener:
             class: Surfnet\StepupMiddleware\ApiBundle\EventListener\ExceptionListener
             arguments:
-                - @logger
+                - "@logger"
             tags:
                 - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
 
@@ -205,6 +205,6 @@ services:
     surfnet_stepup_middleware_api.service.vetting_location:
         class: Surfnet\StepupMiddleware\ApiBundle\Service\VettingLocationService
         arguments:
-            - '@surfnet_stepup_middleware_api.service.institution_with_ra_locations'
-            - '@surfnet_stepup_middleware_api.service.ra_location'
-            - '@surfnet_stepup_middleware_api.service.ra_listing'
+            - "@surfnet_stepup_middleware_api.service.institution_with_ra_locations"
+            - "@surfnet_stepup_middleware_api.service.ra_location"
+            - "@surfnet_stepup_middleware_api.service.ra_listing"

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Service/InstitutionConfigurationOptionsService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Service/InstitutionConfigurationOptionsService.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Service;
+
+use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionConfigurationOptions;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionConfigurationOptionsRepository;
+
+final class InstitutionConfigurationOptionsService
+{
+    /**
+     * @var InstitutionConfigurationOptionsRepository
+     */
+    private $repository;
+
+    public function __construct(InstitutionConfigurationOptionsRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @return InstitutionConfigurationOptions[]
+     */
+    public function findAllInstitutionConfigurationOptions()
+    {
+        return $this->repository->findAll();
+    }
+
+    /**
+     * @param Institution $institution
+     * @return InstitutionConfigurationOptions
+     */
+    public function findInstitutionConfigurationOptionsFor(Institution $institution)
+    {
+        return $this->repository->findConfigurationOptionsFor($institution);
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/ShowRaaContactInformationOptionTypeTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/ShowRaaContactInformationOptionTypeTest.php
@@ -119,16 +119,4 @@ class ShowRaaContactInformationOptionTypeTest extends UnitTest
         $this->assertInstanceOf('Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption', $output);
         $this->assertEquals(new ShowRaaContactInformationOption($input), $output);
     }
-
-    /**
-     * @test
-     * @group doctrine
-     * @expectedException \Doctrine\DBAL\Types\ConversionException
-     */
-    public function an_invalid_database_value_causes_an_exception_upon_conversion()
-    {
-        $configurationInstitution = Type::getType(ShowRaaContactInformationOptionType::NAME);
-
-        $configurationInstitution->convertToPHPValue('a non-boolean value', $this->platform);
-    }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/UseRaLocationsOptionTypeTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/UseRaLocationsOptionTypeTest.php
@@ -119,16 +119,4 @@ class UseRaLocationsOptionTypeTest extends UnitTest
         $this->assertInstanceOf('Surfnet\Stepup\Configuration\Value\UseRaLocationsOption', $output);
         $this->assertEquals(new UseRaLocationsOption($input), $output);
     }
-
-    /**
-     * @test
-     * @group doctrine
-     * @expectedException \Doctrine\DBAL\Types\ConversionException
-     */
-    public function an_invalid_database_value_causes_an_exception_upon_conversion()
-    {
-        $configurationInstitution = Type::getType(UseRaLocationsOptionType::NAME);
-
-        $configurationInstitution->convertToPHPValue('a non-boolean value', $this->platform);
-    }
 }

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/InstitutionConfigurationController.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/InstitutionConfigurationController.php
@@ -48,19 +48,10 @@ final class InstitutionConfigurationController extends Controller
     {
         $this->denyAccessUnlessGranted(['ROLE_MANAGEMENT']);
 
-        $response = array_map(
-            function (InstitutionConfigurationOptions $options) {
-                return [
-                    $options->institution->getInstitution() => [
-                        'use_ra_locations'             => $options->useRaLocationsOption->isEnabled(),
-                        'show_raa_contact_information' => $options->showRaaContactInformationOption->isEnabled(),
-                    ],
-                ];
-            },
-            $this->getInstitutionConfigurationOptionsService()->findAllInstitutionConfigurationOptions()
-        );
+        $institutionConfigurationOptions = $this->getInstitutionConfigurationOptionsService()
+            ->findAllInstitutionConfigurationOptions();
 
-        return new JsonResponse($response);
+        return new JsonResponse($institutionConfigurationOptions);
     }
 
     public function reconfigureAction(Request $request)

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/InstitutionConfigurationController.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/InstitutionConfigurationController.php
@@ -46,6 +46,8 @@ final class InstitutionConfigurationController extends Controller
 {
     public function showAction()
     {
+        $this->denyAccessUnlessGranted(['ROLE_MANAGEMENT']);
+
         $response = array_map(
             function (InstitutionConfigurationOptions $options) {
                 return [

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Resources/config/routing.yml
@@ -1,3 +1,9 @@
+management_institution_configuration_show:
+    path:      /institution-configuration
+    defaults: { _controller: SurfnetStepupMiddlewareManagementBundle:InstitutionConfiguration:show }
+    methods:   [GET]
+    condition: "request.headers.get('Content-Type') == 'application/json' && request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
+
 management_configuration_update:
     path:     /configuration
     defaults: { _controller: SurfnetStepupMiddlewareManagementBundle:Configuration:update }

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Resources/config/routing.yml
@@ -1,13 +1,13 @@
-management_institution_configuration_show:
-    path:      /institution-configuration
-    defaults: { _controller: SurfnetStepupMiddlewareManagementBundle:InstitutionConfiguration:show }
-    methods:   [GET]
-    condition: "request.headers.get('Content-Type') == 'application/json' && request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
-
 management_configuration_update:
     path:     /configuration
     defaults: { _controller: SurfnetStepupMiddlewareManagementBundle:Configuration:update }
     methods:   [POST]
+    condition: "request.headers.get('Content-Type') == 'application/json' && request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
+
+management_institution_configuration_show:
+    path:      /institution-configuration
+    defaults: { _controller: SurfnetStepupMiddlewareManagementBundle:InstitutionConfiguration:show }
+    methods:   [GET]
     condition: "request.headers.get('Content-Type') == 'application/json' && request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
 
 management_institution_configuration_reconfigure:

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Controller/InstitutionConfigurationControllerTest.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Controller/InstitutionConfigurationControllerTest.php
@@ -90,8 +90,9 @@ class InstitutionConfigurationControllerTest extends WebTestCase
      * @group management
      *
      * @dataProvider invalidHttpMethodProvider
+     * @param $invalidHttpMethod
      */
-    public function only_post_requests_are_accepted($invalidHttpMethod)
+    public function only_post_and_get_requests_are_accepted($invalidHttpMethod)
     {
         $this->client->request(
             $invalidHttpMethod,
@@ -106,6 +107,29 @@ class InstitutionConfigurationControllerTest extends WebTestCase
         );
 
         $this->assertEquals('405', $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @test
+     * @group management
+     */
+    public function a_get_request_without_content_is_valid()
+    {
+        $this->client->request(
+            'GET',
+            '/management/institution-configuration',
+            [],
+            [],
+            [
+                'HTTP_ACCEPT'  => 'application/json',
+                'CONTENT_TYPE' => 'application/json',
+                'PHP_AUTH_USER' => 'management',
+                'PHP_AUTH_PW'   => $this->password,
+            ],
+            json_encode([])
+        );
+
+        $this->assertEquals('200', $this->client->getResponse()->getStatusCode());
     }
 
     /**
@@ -137,16 +161,14 @@ class InstitutionConfigurationControllerTest extends WebTestCase
     }
 
     /**
-     * Dataprovider for only_post_requests_are_accepted
+     * Dataprovider for only_post_and_get_requests_are_accepted
      */
     public function invalidHttpMethodProvider()
     {
         return [
-            'GET' => ['GET'],
-            'DELETE' => ['DELETE'],
-            'HEAD' => ['HEAD'],
-            'PUT' => ['PUT'],
-            'OPTIONS' => ['OPTIONS']
+            'DELETE'  => ['DELETE'],
+            'PUT'     => ['PUT'],
+            'OPTIONS' => ['OPTIONS'],
         ];
     }
 }

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Controller/InstitutionConfigurationControllerTest.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Controller/InstitutionConfigurationControllerTest.php
@@ -45,7 +45,7 @@ class InstitutionConfigurationControllerTest extends WebTestCase
      * @test
      * @group management
      */
-    public function authorization_is_required_for_posting()
+    public function authorization_is_required_for_reconfiguring_institution_configuration_options()
     {
         $this->client->request(
             'POST',
@@ -66,7 +66,7 @@ class InstitutionConfigurationControllerTest extends WebTestCase
      * @test
      * @group management
      */
-    public function authorization_is_required_for_getting()
+    public function authorization_is_required_for_querying_institution_configuration_options()
     {
         $this->client->request(
             'GET',

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Controller/InstitutionConfigurationControllerTest.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Controller/InstitutionConfigurationControllerTest.php
@@ -45,10 +45,31 @@ class InstitutionConfigurationControllerTest extends WebTestCase
      * @test
      * @group management
      */
-    public function authorization_is_required()
+    public function authorization_is_required_for_posting()
     {
         $this->client->request(
             'POST',
+            '/management/institution-configuration',
+            [],
+            [],
+            [
+                'HTTP_ACCEPT'   => 'application/json',
+                'CONTENT_TYPE'  => 'application/json',
+            ],
+            json_encode([])
+        );
+
+        $this->assertEquals('401', $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @test
+     * @group management
+     */
+    public function authorization_is_required_for_getting()
+    {
+        $this->client->request(
+            'GET',
             '/management/institution-configuration',
             [],
             [],


### PR DESCRIPTION
* Corrected boolean type conversion in custom Doctrine types
* Corrected exception messages for type conversion
* Corrected quoting in `ApiBundle/Resources/config/services.yml`
* Added action to show the options for all InstitutionConfigurations:
```
GET management/institution-configuration

[
  {
    "dev.organisation.example": {
      "use_ra_locations": false,
      "show_raa_contact_information": true
    }
  },
 ...
  {
    "yubi.organisation.example": {
      "use_ra_locations": false,
      "show_raa_contact_information": true
    }
  }
]
```