### PR TITLE
Add API for institution configuration options for institution

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Repository/InstitutionConfigurationOptionsRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Repository/InstitutionConfigurationOptionsRepository.php
@@ -38,7 +38,7 @@ final class InstitutionConfigurationOptionsRepository extends EntityRepository
             ->where('ico.institution = :institution')
             ->setParameter('institution', $institution->getInstitution())
             ->getQuery()
-            ->getSingleResult();
+            ->getOneOrNullResult();
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
+
+use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\StepupMiddleware\ApiBundle\Service\InstitutionConfigurationOptionsService;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+final class InstitutionConfigurationOptionsController extends Controller
+{
+    public function getForInstitutionAction($institution)
+    {
+        $this->denyAccessUnlessGranted(['ROLE_SS', 'ROLE_RA']);
+
+        $institutionConfigurationOptions = $this
+            ->getInstitutionConfigurationOptionsService()
+            ->findInstitutionConfigurationOptionsFor(new Institution($institution));
+
+        return new JsonResponse(
+            [
+                'use_ra_locations'             => $institutionConfigurationOptions->useRaLocationsOption->isEnabled(),
+                'show_raa_contact_information' => $institutionConfigurationOptions
+                    ->showRaaContactInformationOption->isEnabled(),
+            ]
+        );
+    }
+
+    /**
+     * @return InstitutionConfigurationOptionsService
+     */
+    private function getInstitutionConfigurationOptionsService()
+    {
+        return $this->get('surfnet_stepup_middleware_api.service.institution_configuration_options');
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
 use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\StepupMiddleware\ApiBundle\Exception\BadApiRequestException;
 use Surfnet\StepupMiddleware\ApiBundle\Service\InstitutionConfigurationOptionsService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -33,6 +34,11 @@ final class InstitutionConfigurationOptionsController extends Controller
             ->getInstitutionConfigurationOptionsService()
             ->findInstitutionConfigurationOptionsFor(new Institution($institution));
 
+        if ($institutionConfigurationOptions === null) {
+            throw new BadApiRequestException([
+                sprintf('No institution configuration options found for institution "%s"', $institution)
+            ]);
+        }
 
         return new JsonResponse($institutionConfigurationOptions);
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
@@ -33,13 +33,8 @@ final class InstitutionConfigurationOptionsController extends Controller
             ->getInstitutionConfigurationOptionsService()
             ->findInstitutionConfigurationOptionsFor(new Institution($institution));
 
-        return new JsonResponse(
-            [
-                'use_ra_locations'             => $institutionConfigurationOptions->useRaLocationsOption->isEnabled(),
-                'show_raa_contact_information' => $institutionConfigurationOptions
-                    ->showRaaContactInformationOption->isEnabled(),
-            ]
-        );
+
+        return new JsonResponse($institutionConfigurationOptions);
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
@@ -19,10 +19,10 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
 use Surfnet\Stepup\Configuration\Value\Institution;
-use Surfnet\StepupMiddleware\ApiBundle\Exception\BadApiRequestException;
 use Surfnet\StepupMiddleware\ApiBundle\Service\InstitutionConfigurationOptionsService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 final class InstitutionConfigurationOptionsController extends Controller
 {
@@ -35,9 +35,9 @@ final class InstitutionConfigurationOptionsController extends Controller
             ->findInstitutionConfigurationOptionsFor(new Institution($institution));
 
         if ($institutionConfigurationOptions === null) {
-            throw new BadApiRequestException([
+            throw new NotFoundHttpException(
                 sprintf('No institution configuration options found for institution "%s"', $institution)
-            ]);
+            );
         }
 
         return new JsonResponse($institutionConfigurationOptions);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
@@ -143,3 +143,11 @@ ra_location:
     requirements:
         raLocationId: ".+"
     condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
+
+institution_configuration_options_for_institution:
+    path:    /institution-configuration-options/{institution}
+    defaults: { _controller: SurfnetStepupMiddlewareApiBundle:InstitutionConfigurationOptions:getForInstitution }
+    methods:  [GET]
+    requirements:
+        institution: ".+"
+    condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
@@ -145,7 +145,7 @@ ra_location:
     condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
 
 institution_configuration_options_for_institution:
-    path:    /institution-configuration-options/{institution}
+    path:     /institution-configuration-options/{institution}
     defaults: { _controller: SurfnetStepupMiddlewareApiBundle:InstitutionConfigurationOptions:getForInstitution }
     methods:  [GET]
     requirements:


### PR DESCRIPTION
This depends on the service introduced in #146 

```
GET /institution-configuration-options/dev.organisation.example

{
  "use_ra_locations": false,
  "show_raa_contact_information": true
}
```