### PR TITLE
Correct JSON serialization for institution configuration

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/InstitutionConfigurationOptions.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/InstitutionConfigurationOptions.php
@@ -71,10 +71,9 @@ final class InstitutionConfigurationOptions implements JsonSerializable
     {
         return
             [
-                $this->institution->getInstitution() => [
-                    'use_ra_locations'             => $this->useRaLocationsOption,
-                    'show_raa_contact_information' => $this->showRaaContactInformationOption,
-                ],
+                'institution'                  => $this->institution,
+                'use_ra_locations'             => $this->useRaLocationsOption,
+                'show_raa_contact_information' => $this->showRaaContactInformationOption,
             ];
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
@@ -40,10 +40,7 @@ final class InstitutionConfigurationOptionsController extends Controller
             );
         }
 
-        return new JsonResponse([
-            'use_ra_locations'             => $institutionConfigurationOptions->useRaLocationsOption,
-            'show_raa_contact_information' => $institutionConfigurationOptions->showRaaContactInformationOption,
-        ]);
+        return new JsonResponse($institutionConfigurationOptions);
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
@@ -40,7 +40,10 @@ final class InstitutionConfigurationOptionsController extends Controller
             );
         }
 
-        return new JsonResponse($institutionConfigurationOptions);
+        return new JsonResponse([
+            'use_ra_locations'             => $institutionConfigurationOptions->useRaLocationsOption,
+            'show_raa_contact_information' => $institutionConfigurationOptions->showRaaContactInformationOption,
+        ]);
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/ConfiguredInstitutionTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/ConfiguredInstitutionTest.php
@@ -22,7 +22,6 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Surfnet\Stepup\Configuration\Value\Institution;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\ConfiguredInstitution;
 
-
 class ConfiguredInstitutionTest extends TestCase
 {
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/ConfiguredInstitutionTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/ConfiguredInstitutionTest.php
@@ -29,37 +29,16 @@ class ConfiguredInstitutionTest extends TestCase
      * @test
      * @group entity
      */
-    public function serialized_configured_institution_has_the_correct_keys()
+    public function a_configured_institution_is_correctly_serialized_to_json()
     {
-        $configuredInstitution = ConfiguredInstitution::createFrom(new Institution('An institution'));
-
-        $serialized   = json_encode($configuredInstitution);
-        $deserialized = json_decode($serialized, true);
-
-        $expectedKeys = ['institution'];
-
-        $this->assertCount(
-            count($expectedKeys),
-            $deserialized,
-            'Serialized ConfiguredInstitution does not have the expected amount of keys'
+        $deserializedConfiguredInstitution = ['institution' => 'surfnet.nl'];
+        $configuredInstitution = ConfiguredInstitution::createFrom(
+            new Institution($deserializedConfiguredInstitution['institution'])
         );
 
-        foreach ($expectedKeys as $key) {
-            $this->assertArrayHasKey($key, $deserialized, sprintf('Serialized ConfiguredInstitution is missing key "%s"', $key));
-        }
-    }
+        $expectedSerializedConfiguredInstitution = json_encode($deserializedConfiguredInstitution);
+        $actualSerializedConfiguredInstitution   = json_encode($configuredInstitution);
 
-    /**
-     * @test
-     * @group entity
-     */
-    public function serialized_configured_institution_has_the_correct_values()
-    {
-        $configuredInstitution = ConfiguredInstitution::createFrom(new Institution('An institution'));
-
-        $serialized   = json_encode($configuredInstitution);
-        $deserialized = json_decode($serialized, true);
-
-        $this->assertSame($configuredInstitution->institution->getInstitution(), $deserialized['institution']);
+        $this->assertSame($expectedSerializedConfiguredInstitution, $actualSerializedConfiguredInstitution);
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/ConfiguredInstitutionTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/ConfiguredInstitutionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Tests\Configuration\Entity;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\ConfiguredInstitution;
+
+
+class ConfiguredInstitutionTest extends TestCase
+{
+    /**
+     * @test
+     * @group entity
+     */
+    public function serialized_configured_institution_has_the_correct_keys()
+    {
+        $configuredInstitution = ConfiguredInstitution::createFrom(new Institution('An institution'));
+
+        $serialized   = json_encode($configuredInstitution);
+        $deserialized = json_decode($serialized, true);
+
+        $expectedKeys = ['institution'];
+
+        $this->assertCount(
+            count($expectedKeys),
+            $deserialized,
+            'Serialized ConfiguredInstitution does not have the expected amount of keys'
+        );
+
+        foreach ($expectedKeys as $key) {
+            $this->assertArrayHasKey($key, $deserialized, sprintf('Serialized ConfiguredInstitution is missing key "%s"', $key));
+        }
+    }
+
+    /**
+     * @test
+     * @group entity
+     */
+    public function serialized_configured_institution_has_the_correct_values()
+    {
+        $configuredInstitution = ConfiguredInstitution::createFrom(new Institution('An institution'));
+
+        $serialized   = json_encode($configuredInstitution);
+        $deserialized = json_decode($serialized, true);
+
+        $this->assertSame($configuredInstitution->institution->getInstitution(), $deserialized['institution']);
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/InstitutionConfigurationOptionsTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/InstitutionConfigurationOptionsTest.php
@@ -33,8 +33,8 @@ class InstitutionConfigurationOptionsTest extends TestCase
     public function institution_configuration_options_are_correctly_serialized_to_json()
     {
         $deserializedInstitutionConfigurationOptions = [
-            'institution'                          => 'surfnet.nl',
-            'use_ra_locations'                     => true,
+            'institution'                  => 'surfnet.nl',
+            'use_ra_locations'             => true,
             'show_raa_contact_information' => true,
         ];
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/InstitutionConfigurationOptionsTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/InstitutionConfigurationOptionsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Tests\Configuration\Entity;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
+use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionConfigurationOptions;
+
+class InstitutionConfigurationOptionsTest extends TestCase
+{
+    /**
+     * @test
+     * @group entity
+     */
+    public function serialized_institution_configuration_options_have_the_correct_keys()
+    {
+        $institutionConfigurationOptions = InstitutionConfigurationOptions::create(
+            new Institution('An institution'),
+            new UseRaLocationsOption(true),
+            new ShowRaaContactInformationOption(true)
+        );
+
+        $serialized   = json_encode($institutionConfigurationOptions);
+        $deserialized = json_decode($serialized, true);
+
+        $this->assertArrayHasKey('institution', $deserialized);
+        $this->assertArrayHasKey('use_ra_locations', $deserialized);
+        $this->assertArrayHasKey('show_raa_contact_information', $deserialized);
+    }
+
+    /**
+     * @test
+     * @group entity
+     */
+    public function serialized_institution_configuration_options_have_the_correct_values()
+    {
+        $institutionConfigurationOptions = InstitutionConfigurationOptions::create(
+            new Institution('An institution'),
+            new UseRaLocationsOption(true),
+            new ShowRaaContactInformationOption(true)
+        );
+
+        $serialized   = json_encode($institutionConfigurationOptions);
+        $deserialized = json_decode($serialized, true);
+
+        $this->assertSame(
+            $institutionConfigurationOptions->institution->getInstitution(),
+            $deserialized['institution']
+        );
+        $this->assertSame(
+            $institutionConfigurationOptions->useRaLocationsOption->isEnabled(),
+            $deserialized['use_ra_locations']
+        );
+        $this->assertSame(
+            $institutionConfigurationOptions->showRaaContactInformationOption->isEnabled(),
+            $deserialized['show_raa_contact_information']
+        );
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/InstitutionConfigurationOptionsTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/InstitutionConfigurationOptionsTest.php
@@ -41,9 +41,21 @@ class InstitutionConfigurationOptionsTest extends TestCase
         $serialized   = json_encode($institutionConfigurationOptions);
         $deserialized = json_decode($serialized, true);
 
-        $this->assertArrayHasKey('institution', $deserialized);
-        $this->assertArrayHasKey('use_ra_locations', $deserialized);
-        $this->assertArrayHasKey('show_raa_contact_information', $deserialized);
+        $expectedKeys = ['institution', 'use_ra_locations', 'show_raa_contact_information'];
+
+        $this->assertCount(
+            count($expectedKeys),
+            $deserialized,
+            'Serialized InstitutionConfigurationOptions do not have the expected amount of keys'
+        );
+
+        foreach ($expectedKeys as $key) {
+            $this->assertArrayHasKey(
+                $key,
+                $deserialized,
+                sprintf('Serialized InstitutionConfigurationOptions are missing key "%s"', $key)
+            );
+        }
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/InstitutionConfigurationOptionsTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/InstitutionConfigurationOptionsTest.php
@@ -30,60 +30,28 @@ class InstitutionConfigurationOptionsTest extends TestCase
      * @test
      * @group entity
      */
-    public function serialized_institution_configuration_options_have_the_correct_keys()
+    public function institution_configuration_options_are_correctly_serialized_to_json()
     {
+        $deserializedInstitutionConfigurationOptions = [
+            'institution'                          => 'surfnet.nl',
+            'use_ra_locations'                     => true,
+            'show_raa_contact_information' => true,
+        ];
+
         $institutionConfigurationOptions = InstitutionConfigurationOptions::create(
-            new Institution('An institution'),
-            new UseRaLocationsOption(true),
-            new ShowRaaContactInformationOption(true)
+            new Institution($deserializedInstitutionConfigurationOptions['institution']),
+            new UseRaLocationsOption($deserializedInstitutionConfigurationOptions['use_ra_locations']),
+            new ShowRaaContactInformationOption(
+                $deserializedInstitutionConfigurationOptions['show_raa_contact_information']
+            )
         );
 
-        $serialized   = json_encode($institutionConfigurationOptions);
-        $deserialized = json_decode($serialized, true);
-
-        $expectedKeys = ['institution', 'use_ra_locations', 'show_raa_contact_information'];
-
-        $this->assertCount(
-            count($expectedKeys),
-            $deserialized,
-            'Serialized InstitutionConfigurationOptions do not have the expected amount of keys'
-        );
-
-        foreach ($expectedKeys as $key) {
-            $this->assertArrayHasKey(
-                $key,
-                $deserialized,
-                sprintf('Serialized InstitutionConfigurationOptions are missing key "%s"', $key)
-            );
-        }
-    }
-
-    /**
-     * @test
-     * @group entity
-     */
-    public function serialized_institution_configuration_options_have_the_correct_values()
-    {
-        $institutionConfigurationOptions = InstitutionConfigurationOptions::create(
-            new Institution('An institution'),
-            new UseRaLocationsOption(true),
-            new ShowRaaContactInformationOption(true)
-        );
-
-        $serialized   = json_encode($institutionConfigurationOptions);
-        $deserialized = json_decode($serialized, true);
+        $expectedSerializedInstitutionConfigurationOptions = json_encode($deserializedInstitutionConfigurationOptions);
+        $actualSerializedInstitutionConfigurationOptions   = json_encode($institutionConfigurationOptions);
 
         $this->assertSame(
-            $institutionConfigurationOptions->institution->getInstitution(),
-            $deserialized['institution']
-        );
-        $this->assertSame(
-            $institutionConfigurationOptions->useRaLocationsOption->isEnabled(),
-            $deserialized['use_ra_locations']
-        );
-        $this->assertSame(
-            $institutionConfigurationOptions->showRaaContactInformationOption->isEnabled(),
-            $deserialized['show_raa_contact_information']
+            $expectedSerializedInstitutionConfigurationOptions,
+            $actualSerializedInstitutionConfigurationOptions
         );
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/RaLocationTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/RaLocationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Tests\Configuration\Entity;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Surfnet\Stepup\Configuration\Value\ContactInformation;
+use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\Stepup\Configuration\Value\Location;
+use Surfnet\Stepup\Configuration\Value\RaLocationName;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\RaLocation;
+
+class RaLocationTest extends TestCase
+{
+    /**
+     * @test
+     * @group entity
+     */
+    public function serialized_ra_location_has_the_correct_keys()
+    {
+        $raLocation = RaLocation::create(
+            'An id',
+            new Institution('An institution'),
+            new RaLocationName('An RA location'),
+            new Location('A location'),
+            new ContactInformation('Contact information')
+        );
+
+        $serialized   = json_encode($raLocation);
+        $deserialized = json_decode($serialized, true);
+
+        $expectedKeys = ['id', 'institution', 'name', 'location', 'contact_information'];
+
+        $this->assertCount(
+            count($expectedKeys),
+            $deserialized,
+            'Serialized RaLocation does not have the expected amount of keys'
+        );
+
+        foreach ($expectedKeys as $key) {
+            $this->assertArrayHasKey($key, $deserialized, sprintf('Serialized RaLocation is missing key "%s"', $key));
+        }
+    }
+
+    /**
+     * @test
+     * @group entity
+     */
+    public function serialized_ra_location_has_the_correct_values()
+    {
+        $raLocation = RaLocation::create(
+            'An id',
+            new Institution('An institution'),
+            new RaLocationName('An RA location'),
+            new Location('A location'),
+            new ContactInformation('Contact information')
+        );
+
+        $serialized   = json_encode($raLocation);
+        $deserialized = json_decode($serialized, true);
+
+        $this->assertSame($raLocation->id, $deserialized['id']);
+        $this->assertSame($raLocation->institution->getInstitution(), $deserialized['institution']);
+        $this->assertSame($raLocation->name->getRaLocationName(), $deserialized['name']);
+        $this->assertSame($raLocation->location->getLocation(), $deserialized['location']);
+        $this->assertSame(
+            $raLocation->contactInformation->getContactInformation(),
+            $deserialized['contact_information']
+        );
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/RaLocationTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/RaLocationTest.php
@@ -31,56 +31,27 @@ class RaLocationTest extends TestCase
      * @test
      * @group entity
      */
-    public function serialized_ra_location_has_the_correct_keys()
+    public function an_ra_location_is_correctly_serialized_to_json()
     {
+        $deserializedRaLocation = [
+            'id'                  => 'An id',
+            'institution'         => 'surfnet.nl',
+            'name'                => 'An RA location',
+            'location'            => 'A location',
+            'contact_information' => 'Contact information',
+        ];
+
         $raLocation = RaLocation::create(
-            'An id',
-            new Institution('An institution'),
-            new RaLocationName('An RA location'),
-            new Location('A location'),
-            new ContactInformation('Contact information')
+            $deserializedRaLocation['id'],
+            new Institution($deserializedRaLocation['institution']),
+            new RaLocationName($deserializedRaLocation['name']),
+            new Location($deserializedRaLocation['location']),
+            new ContactInformation($deserializedRaLocation['contact_information'])
         );
 
-        $serialized   = json_encode($raLocation);
-        $deserialized = json_decode($serialized, true);
+        $expectedSerialization = json_encode($deserializedRaLocation);
+        $actualSerialization   = json_encode($raLocation);
 
-        $expectedKeys = ['id', 'institution', 'name', 'location', 'contact_information'];
-
-        $this->assertCount(
-            count($expectedKeys),
-            $deserialized,
-            'Serialized RaLocation does not have the expected amount of keys'
-        );
-
-        foreach ($expectedKeys as $key) {
-            $this->assertArrayHasKey($key, $deserialized, sprintf('Serialized RaLocation is missing key "%s"', $key));
-        }
-    }
-
-    /**
-     * @test
-     * @group entity
-     */
-    public function serialized_ra_location_has_the_correct_values()
-    {
-        $raLocation = RaLocation::create(
-            'An id',
-            new Institution('An institution'),
-            new RaLocationName('An RA location'),
-            new Location('A location'),
-            new ContactInformation('Contact information')
-        );
-
-        $serialized   = json_encode($raLocation);
-        $deserialized = json_decode($serialized, true);
-
-        $this->assertSame($raLocation->id, $deserialized['id']);
-        $this->assertSame($raLocation->institution->getInstitution(), $deserialized['institution']);
-        $this->assertSame($raLocation->name->getRaLocationName(), $deserialized['name']);
-        $this->assertSame($raLocation->location->getLocation(), $deserialized['location']);
-        $this->assertSame(
-            $raLocation->contactInformation->getContactInformation(),
-            $deserialized['contact_information']
-        );
+       $this->assertSame($expectedSerialization, $actualSerialization);
     }
 }

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/InstitutionConfigurationController.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/InstitutionConfigurationController.php
@@ -51,7 +51,12 @@ final class InstitutionConfigurationController extends Controller
         $institutionConfigurationOptions = $this->getInstitutionConfigurationOptionsService()
             ->findAllInstitutionConfigurationOptions();
 
-        return new JsonResponse($institutionConfigurationOptions);
+        $overview = [];
+        foreach ($institutionConfigurationOptions as $options) {
+            $overview[$options->institution->getInstitution()] = $options;
+        }
+
+        return new JsonResponse($overview);
     }
 
     public function reconfigureAction(Request $request)


### PR DESCRIPTION
This PR:
* Changes the way InstitutionConfigurationOptions are serialized
* Adds tests for serialization of Configuration related Doctrine entitites (boyscout)