### PR TITLE
More specific configuration allows succesful cache:clear on prod

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -111,11 +111,17 @@ doctrine:
                 connection: middleware
                 naming_strategy: doctrine.orm.naming_strategy.underscore
                 mappings:
-                    api:
+                    api_identity:
                         mapping: true
                         type: annotation
-                        dir: %kernel.root_dir%/../src/Surfnet/StepupMiddleware/ApiBundle
-                        prefix: Surfnet\StepupMiddleware\ApiBundle
+                        dir: %kernel.root_dir%/../src/Surfnet/StepupMiddleware/ApiBundle/Identity
+                        prefix: Surfnet\StepupMiddleware\ApiBundle\Identity
+                        is_bundle: false
+                    api_configuration:
+                        mapping: true
+                        type: annotation
+                        dir: %kernel.root_dir%/../src/Surfnet/StepupMiddleware/ApiBundle/Configuration
+                        prefix: Surfnet\StepupMiddleware\ApiBundle\Configuration
                         is_bundle: false
                     management_configuration:
                         mapping: true


### PR DESCRIPTION
Initial error report:

> ```sh
[root@test-app Stepup-Middleware-2.0.0-20160808152839Z-b38acd98a77c89bffa2649d956f92709954aa036]# php app/console cache:clear --env=prod --no-debug
Clearing the cache for the prod environment with debug false
PHP Fatal error:  Class 'PHPUnit_Framework_TestCase' not found in /opt/stepup/Stepup-Middleware-2.0.0-20160808152839Z-b38acd98a77c89bffa2649d956f92709954aa036/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/ConfiguredInstitutionTest.php on line 26
[Symfony\Component\Debug\Exception\ClassNotFoundException] Attempted to load class "PHPUnit_Framework_TestCase" from the global namespace.  Did you forget a "use" statement?
```

What seems to happen is that the cache cannot be cleared due to Test classes being loaded during the `cache:clear` command.

In order to reproduce this locally, run:
```sh
SYMFONY_ENV=prod composer install -o --no-dev
```

This should remove any dev dependencies and then attempt to clear the cache as if Symfony was running in prod mode, therefor causing a similar or the same error. This is reproducible with a command as reported originally:
```sh
SYMFONY_ENV=prod app/console c:c --env=prod --no-debug
```

For me this resulted in:
```
Clearing the cache for the prod environment with debug false
PHP Fatal error:  Class 'PHPUnit_Framework_TestCase' not found in /opt/workspace/SURFnet/Stepup-Middleware/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Entity/RaLocationTest.php on line 28
PHP Stack trace:
PHP   1. {main}() /opt/workspace/SURFnet/Stepup-Middleware/app/console:0
PHP   2. Symfony\Component\Console\Application->run() /opt/workspace/SURFnet/Stepup-Middleware/app/console:25
PHP   3. Symfony\Bundle\FrameworkBundle\Console\Application->doRun() /opt/workspace/SURFnet/Stepup-Middleware/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:120
PHP   4. Symfony\Component\Console\Application->doRun() /opt/workspace/SURFnet/Stepup-Middleware/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:90
PHP   5. Symfony\Component\Console\Application->doRunCommand() /opt/workspace/SURFnet/Stepup-Middleware/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:189
PHP   6. Symfony\Component\Console\Command\Command->run() /opt/workspace/SURFnet/Stepup-Middleware/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:852
PHP   7. Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->execute() /opt/workspace/SURFnet/Stepup-Middleware/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:256
PHP   8. Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->warmup() /opt/workspace/SURFnet/Stepup-Middleware/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php:92
PHP   9. Symfony\Component\HttpKernel\Kernel->boot() /opt/workspace/SURFnet/Stepup-Middleware/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php:128
PHP  10. Symfony\Component\HttpKernel\Kernel->initializeContainer() /opt/workspace/SURFnet/Stepup-Middleware/app/bootstrap.php.cache:2447
PHP  11. Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate->warmUp() /opt/workspace/SURFnet/Stepup-Middleware/app/bootstrap.php.cache:2677
PHP  12. Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer->warmUp() /opt/workspace/SURFnet/Stepup-Middleware/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php:48
PHP  13. Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory->getAllMetadata() /opt/workspace/SURFnet/Stepup-Middleware/vendor/symfony/symfony/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php:69
PHP  14. Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain->getAllClassNames() /opt/workspace/SURFnet/Stepup-Middleware/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php:114
PHP  15. Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver->getAllClassNames() /opt/workspace/SURFnet/Stepup-Middleware/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php:128
PHP  16. require_once() /opt/workspace/SURFnet/Stepup-Middleware/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php:236

                                                                                   
  [Symfony\Component\Debug\Exception\ClassNotFoundException]                       
  Attempted to load class "PHPUnit_Framework_TestCase" from the global namespace.  
  Did you forget a "use" statement?                                                
                                                                                   

cache:clear [--no-warmup] [--no-optional-warmers]
```

This indicated that Doctrine was the culprit when attempting to generate the cache files for all entities within a specific mapping. This would trigger loading of test files, which apparently breaks things. Being more specific in the mapping circumvents this.