### PR TITLE
Change name of migration, influencing execution order

### DIFF
--- a/app/DoctrineMigrations/Version20160719090051.php
+++ b/app/DoctrineMigrations/Version20160719090051.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Schema\Schema;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-class Version20160728074605 extends AbstractMigration
+class Version20160719090051 extends AbstractMigration
 {
     /**
      * @param Schema $schema


### PR DESCRIPTION
This ensures that this migration runs before a migration that depends on this migration being run.

Reported error:
```
migrating up to 20160728074605 from 20160607142244
…
++ migrating 20160719090052

Migration 20160719090052 failed during Execution. Error An exception occurred while executing 'INSERT INTO institution_configuration_options (institution, use_ra_locations_option, show_raa_contact_information_option) VALUES (?, ?, ?)' with params ["institution-a.nl", false, true]:

SQLSTATE[42S02]: Base table or view not found: 1146 Table 'middleware.institution_configuration_options' doesn't exist
```

Probable cause would be that after the creation of migration `20160719090052` the events as the result of commands triggered in that migration have been changed for other events, as well as the projectors are different and require the presence of a table generated by the migration that is now run before the `20160719090052` migration.