### PR TITLE
Clear entity managers references after each event

### DIFF
--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/event_sourcing.yml
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/event_sourcing.yml
@@ -55,6 +55,8 @@ services:
     surfnet_stepup_middleware_command_handling.event_bus.buffered:
         public: false
         class: Surfnet\StepupMiddleware\CommandHandlingBundle\EventHandling\BufferedEventBus
+        arguments:
+            - @doctrine.orm.entity_manager
 
     # Sensitive data
     surfnet_stepup_middleware_command_handling.repository.sensitive_data_message:

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/EventHandling/BufferedEventBusTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/EventHandling/BufferedEventBusTest.php
@@ -22,6 +22,7 @@ use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
+use Doctrine\ORM\EntityManagerInterface;
 use Mockery as m;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\EventHandling\BufferedEventBus;
 
@@ -38,7 +39,7 @@ class BufferedEventBusTest extends \PHPUnit_Framework_TestCase
             ->shouldReceive('handle')->never()
             ->getMock();
 
-        $bus = new BufferedEventBus();
+        $bus = new BufferedEventBus($this->getDummyEntityManager());
         $bus->subscribe($listener);
 
         // Currently buses typehint against the concrete DomainEventStream.
@@ -56,7 +57,7 @@ class BufferedEventBusTest extends \PHPUnit_Framework_TestCase
             ->shouldReceive('handle')->once()->with($event)
             ->getMock();
 
-        $bus = new BufferedEventBus();
+        $bus = new BufferedEventBus($this->getDummyEntityManager());
         $bus->subscribe($listener);
 
         // Currently buses typehint against the concrete DomainEventStream.
@@ -76,7 +77,7 @@ class BufferedEventBusTest extends \PHPUnit_Framework_TestCase
             ->shouldReceive('handle')->once()->with($event)
             ->getMock();
 
-        $bus = new BufferedEventBus();
+        $bus = new BufferedEventBus($this->getDummyEntityManager());
         $bus->subscribe($listener);
 
         $bus->publish(new DomainEventStream([$event]));
@@ -90,7 +91,7 @@ class BufferedEventBusTest extends \PHPUnit_Framework_TestCase
      */
     public function an_event_caused_by_an_event_in_the_current_buffer_being_flushed_is_buffered_and_flushed_after_events_in_the_current_buffer()
     {
-        $bus = new BufferedEventBus();
+        $bus = new BufferedEventBus($this->getDummyEntityManager());
 
         $firstEventInCurrentBuffer = $this->createDummyDomainMessage('First event in current buffer');
         $secondEventInCurrentBuffer = $this->createDummyDomainMessage('Second event in current buffer');
@@ -118,6 +119,11 @@ class BufferedEventBusTest extends \PHPUnit_Framework_TestCase
     private function createDummyDomainMessage($payload)
     {
         return new DomainMessage('1', 0, new Metadata(), $payload, DateTime::fromString('1970-01-01H00:00:00.000'));
+    }
+
+    private function getDummyEntityManager()
+    {
+        return m::mock(EntityManagerInterface::class)->shouldIgnoreMissing(true);
     }
 }
 


### PR DESCRIPTION
[132894351](https://www.pivotaltracker.com/story/show/132894351)

Doctrine uses PHP's [spl_object_hash](http://php.net/manual/en/function.spl-object-hash.php). Hashes can be re-assigned after a certain object has been destroyed / garbage collected.

It seems that we have reached an edge case wherein hash collisions occur during event replays. Similar edge cases have been reported at the [Doctrine repository](https://github.com/doctrine/doctrine2/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20spl_object_hash%20).

Clearing the entity manager after each event ensures the entity manager correctly inserts entities that have not been seen before.

This does come with the caveat that event listeners cannot hold references to entities crossing events.