### PR TITLE
RAs should not be able to vet outside institution

### DIFF
--- a/src/Surfnet/Stepup/Identity/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Identity.php
@@ -326,6 +326,10 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
     ) {
         $this->assertNotForgotten();
 
+        if ($this->registrationAuthority === null) {
+            throw new DomainException('Cannot vet second factor: vetting Identity is not a registration authority');
+        }
+
         /** @var VettedSecondFactor|null $secondFactorWithHighestLoa */
         $secondFactorWithHighestLoa = $this->vettedSecondFactors->getSecondFactorWithHighestLoa();
         $registrantsSecondFactor = $registrant->getVerifiedSecondFactor($registrantsSecondFactorId);
@@ -344,7 +348,8 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
             throw new DomainException('Will not vet second factor when physical identity has not been verified.');
         }
 
-        if (!$registrant->getInstitution()->equals($this->institution)) {
+        if (!$registrant->getInstitution()->equals($this->institution)
+        && !$this->registrationAuthority->getRole()->isSraa()) {
             throw new DomainException(sprintf(
                 'Cannot vet registrant of institution "%s", because the RA belongs to a different institution: "%s"',
                 $registrant->getInstitution()->getInstitution(),

--- a/src/Surfnet/Stepup/Identity/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Identity.php
@@ -344,6 +344,14 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
             throw new DomainException('Will not vet second factor when physical identity has not been verified.');
         }
 
+        if (!$registrant->getInstitution()->equals($this->institution)) {
+            throw new DomainException(sprintf(
+                'Cannot vet registrant of institution "%s", because the RA belongs to a different institution: "%s"',
+                $registrant->getInstitution()->getInstitution(),
+                $this->institution->getInstitution()
+            ));
+        }
+
         $registrant->complyWithVettingOfSecondFactor(
             $registrantsSecondFactorId,
             $registrantsSecondFactorType,

--- a/src/Surfnet/Stepup/Identity/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Identity.php
@@ -348,8 +348,10 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
             throw new DomainException('Will not vet second factor when physical identity has not been verified.');
         }
 
-        if (!$registrant->getInstitution()->equals($this->institution)
-        && !$this->registrationAuthority->getRole()->isSraa()) {
+        $raHasDifferentInstitution = !$registrant->getInstitution()->equals($this->institution);
+        $raIsNotSraa               = !$this->registrationAuthority->getRole()->isSraa();
+
+        if ($raHasDifferentInstitution && $raIsNotSraa) {
             throw new DomainException(sprintf(
                 'Cannot vet registrant of institution "%s", because the RA belongs to a different institution: "%s"',
                 $registrant->getInstitution()->getInstitution(),

--- a/src/Surfnet/Stepup/Identity/Value/RegistrationAuthorityRole.php
+++ b/src/Surfnet/Stepup/Identity/Value/RegistrationAuthorityRole.php
@@ -71,6 +71,14 @@ final class RegistrationAuthorityRole implements SerializableInterface
         return $this->role === self::ROLE_RAA;
     }
 
+    /**
+     * return bool
+     */
+    public function isSraa()
+    {
+        return $this->role === self::ROLE_SRAA;
+    }
+
     public function jsonSerialize()
     {
         return $this->role;

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
@@ -1200,7 +1200,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
      * @test
      * @group command-handler
      * @runInSeparateProcess
-     * @expectedException Surfnet\StepupMiddleware\CommandHandlingBundle\Exception\UnsupportedLocaleException
+     * @expectedException \Surfnet\StepupMiddleware\CommandHandlingBundle\Exception\UnsupportedLocaleException
      * @expectedExceptionMessage Given locale "fi_FI" is not a supported locale
      */
     public function an_identity_cannot_express_a_preference_for_an_unsupported_locale()

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
@@ -27,6 +27,7 @@ use Surfnet\Stepup\DateTime\DateTime;
 use Surfnet\Stepup\Identity\Entity\ConfigurableSettings;
 use Surfnet\Stepup\Identity\Event\EmailVerifiedEvent;
 use Surfnet\Stepup\Identity\Event\GssfPossessionProvenEvent;
+use Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaEvent;
 use Surfnet\Stepup\Identity\Event\IdentityCreatedEvent;
 use Surfnet\Stepup\Identity\Event\IdentityEmailChangedEvent;
 use Surfnet\Stepup\Identity\Event\IdentityRenamedEvent;
@@ -38,6 +39,7 @@ use Surfnet\Stepup\Identity\Event\YubikeyPossessionProvenEvent;
 use Surfnet\Stepup\Identity\Event\YubikeySecondFactorBootstrappedEvent;
 use Surfnet\Stepup\Identity\EventSourcing\IdentityRepository;
 use Surfnet\Stepup\Identity\Value\CommonName;
+use Surfnet\Stepup\Identity\Value\ContactInformation;
 use Surfnet\Stepup\Identity\Value\DocumentNumber;
 use Surfnet\Stepup\Identity\Value\Email;
 use Surfnet\Stepup\Identity\Value\EmailVerificationWindow;
@@ -45,8 +47,10 @@ use Surfnet\Stepup\Identity\Value\GssfId;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Locale;
+use Surfnet\Stepup\Identity\Value\Location;
 use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\Stepup\Identity\Value\PhoneNumber;
+use Surfnet\Stepup\Identity\Value\RegistrationAuthorityRole;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\Stepup\Identity\Value\StepupProvider;
 use Surfnet\Stepup\Identity\Value\TimeFrame;
@@ -862,6 +866,14 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     new Locale('en_GB'),
                     new SecondFactorId($this->uuid()),
                     new YubikeyPublicId('00000012')
+                ),
+                new IdentityAccreditedAsRaEvent(
+                    $authorityId,
+                    $authorityNameId,
+                    $authorityInstitution,
+                    new RegistrationAuthorityRole(RegistrationAuthorityRole::ROLE_SRAA),
+                    new Location('House'),
+                    new ContactInformation('Telephone')
                 )
             ])
             ->withAggregateId($registrantId)
@@ -921,10 +933,8 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
     /**
      * @test
      * @group command-handler
-     * @expectedException \Surfnet\Stepup\Exception\DomainException
-     * @expectedExceptionMessage the RA belongs to a different institution
      */
-    public function a_second_factor_cannot_be_vetted_if_the_ra_belongs_to_a_different_institution_than_the_registrant()
+    public function a_second_factor_can_be_vetted_even_though_the_sraa_belongs_to_a_different_institution_than_the_registrant()
     {
         $command                         = new VetSecondFactorCommand();
         $command->authorityId            = 'AID';
@@ -970,6 +980,163 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     new Locale('en_GB'),
                     new SecondFactorId($this->uuid()),
                     new YubikeyPublicId('00000012')
+                ),
+                new IdentityAccreditedAsRaEvent(
+                    $authorityId,
+                    $authorityNameId,
+                    $authorityInstitution,
+                    new RegistrationAuthorityRole(RegistrationAuthorityRole::ROLE_SRAA),
+                    new Location('House'),
+                    new ContactInformation('Telephone')
+                )
+            ])
+            ->withAggregateId($registrantId)
+            ->given([
+                new IdentityCreatedEvent(
+                    $registrantId,
+                    $registrantInstitution,
+                    $registrantNameId,
+                    $registrantCommonName,
+                    $registrantEmail,
+                    new Locale('en_GB')
+                ),
+                new YubikeyPossessionProvenEvent(
+                    $registrantId,
+                    $registrantInstitution,
+                    $registrantSecFacId,
+                    $registrantSecFacIdentifier,
+                    EmailVerificationWindow::createFromTimeFrameStartingAt(
+                        TimeFrame::ofSeconds(static::$window),
+                        DateTime::now()
+                    ),
+                    'nonce',
+                    $registrantCommonName,
+                    $registrantEmail,
+                    new Locale('en_GB')
+                ),
+                new EmailVerifiedEvent(
+                    $registrantId,
+                    $registrantInstitution,
+                    $registrantSecFacId,
+                    new SecondFactorType('yubikey'),
+                    $registrantSecFacIdentifier,
+                    DateTime::now(),
+                    'REGCODE',
+                    $registrantCommonName,
+                    $registrantEmail,
+                    new Locale('en_GB')
+                ),
+            ])
+            ->when($command)
+            ->then([
+                new SecondFactorVettedEvent(
+                    $registrantId,
+                    $registrantNameId,
+                    $registrantInstitution,
+                    $registrantSecFacId,
+                    new SecondFactorType('yubikey'),
+                    new YubikeyPublicId('00028278'),
+                    new DocumentNumber('NH9392'),
+                    $registrantCommonName,
+                    $registrantEmail,
+                    new Locale('en_GB')
+                ),
+            ]);
+    }
+
+    /**
+     * @test
+     * @group command-handler
+     */
+    public function a_second_factor_cannot_be_vetted_if_the_ra_belongs_to_a_different_institution_than_the_registrant()
+    {
+        $this->setExpectedException(
+            'Surfnet\Stepup\Exception\DomainException',
+            'the RA belongs to a different institution'
+        );
+
+        $command                         = new VetSecondFactorCommand();
+        $command->authorityId            = 'AID';
+        $command->identityId             = 'IID';
+        $command->secondFactorId         = 'ISFID';
+        $command->registrationCode       = 'REGCODE';
+        $command->secondFactorType       = 'yubikey';
+        $command->secondFactorIdentifier = '00028278';
+        $command->documentNumber         = 'NH9392';
+        $command->identityVerified       = true;
+
+        $authorityId                = new IdentityId($command->authorityId);
+        $authorityNameId            = new NameId($this->uuid());
+        $authorityInstitution       = new Institution('A Corp.');
+        $authorityEmail             = new Email('info@domain.invalid');
+        $authorityCommonName        = new CommonName('Henk Westbroek');
+        $authoritySecFacId          = new SecondFactorId('AISFID');
+        $authoritySecFacIdentifier  = new YubikeyPublicId('00128278');
+
+        $registrantId                = new IdentityId($command->identityId);
+        $registrantInstitution       = new Institution('A Different Institution Inc.');
+        $registrantNameId            = new NameId('3');
+        $registrantEmail             = new Email('reg@domain.invalid');
+        $registrantCommonName        = new CommonName('Reginald Waterloo');
+        $registrantSecFacId          = new SecondFactorId('ISFID');
+        $registrantSecFacIdentifier  = new YubikeyPublicId('00028278');
+
+        $this->scenario
+            ->withAggregateId($authorityId)
+            ->given([
+                new IdentityCreatedEvent(
+                    $authorityId,
+                    $authorityInstitution,
+                    $authorityNameId,
+                    $authorityCommonName,
+                    $authorityEmail,
+                    new Locale('en_GB')
+                ),
+                new YubikeyPossessionProvenEvent(
+                    $authorityId,
+                    $authorityInstitution,
+                    $authoritySecFacId,
+                    $authoritySecFacIdentifier,
+                    EmailVerificationWindow::createFromTimeFrameStartingAt(
+                        TimeFrame::ofSeconds(static::$window),
+                        DateTime::now()
+                    ),
+                    'nonce',
+                    $authorityCommonName,
+                    $authorityEmail,
+                    new Locale('en_GB')
+                ),
+                new EmailVerifiedEvent(
+                    $authorityId,
+                    $authorityInstitution,
+                    $authoritySecFacId,
+                    new SecondFactorType('yubikey'),
+                    $authoritySecFacIdentifier,
+                    DateTime::now(),
+                    'REGCODE',
+                    $authorityCommonName,
+                    $authorityEmail,
+                    new Locale('en_GB')
+                ),
+                new SecondFactorVettedEvent(
+                    $authorityId,
+                    $authorityNameId,
+                    $authorityInstitution,
+                    $authoritySecFacId,
+                    new SecondFactorType('yubikey'),
+                    new YubikeyPublicId('00128278'),
+                    new DocumentNumber('XX9392'),
+                    $authorityCommonName,
+                    $authorityEmail,
+                    new Locale('en_GB')
+                ),
+                new IdentityAccreditedAsRaEvent(
+                    $authorityId,
+                    $authorityNameId,
+                    $authorityInstitution,
+                    new RegistrationAuthorityRole(RegistrationAuthorityRole::ROLE_RA),
+                    new Location('House'),
+                    new ContactInformation('Telephone')
                 )
             ])
             ->withAggregateId($registrantId)
@@ -1108,6 +1275,14 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     $authorityCommonName,
                     $authorityEmail,
                     new Locale('en_GB')
+                ),
+                new IdentityAccreditedAsRaEvent(
+                    $authorityId,
+                    $authorityNameId,
+                    $authorityInstitution,
+                    new RegistrationAuthorityRole(RegistrationAuthorityRole::ROLE_RA),
+                    new Location('House'),
+                    new ContactInformation('Telephone')
                 )
             ])
             ->withAggregateId($registrantId)

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
@@ -934,6 +934,103 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
      * @test
      * @group command-handler
      */
+    public function only_registration_authorities_can_vet_second_factors()
+    {
+        $this->setExpectedException(
+            'Surfnet\Stepup\Exception\DomainException',
+            'vetting Identity is not a registration authority'
+        );
+
+        $command                         = new VetSecondFactorCommand();
+        $command->authorityId            = 'AID';
+        $command->identityId             = 'IID';
+        $command->secondFactorId         = 'ISFID';
+        $command->registrationCode       = 'REGCODE';
+        $command->secondFactorType       = 'yubikey';
+        $command->secondFactorIdentifier = '00028278';
+        $command->documentNumber         = 'NH9392';
+        $command->identityVerified       = true;
+
+        $authorityId                = new IdentityId($command->authorityId);
+        $authorityNameId            = new NameId($this->uuid());
+        $authorityInstitution       = new Institution('A Corp.');
+        $authorityEmail             = new Email('info@domain.invalid');
+        $authorityCommonName        = new CommonName('Henk Westbroek');
+
+        $registrantId                = new IdentityId($command->identityId);
+        $registrantInstitution       = new Institution('A Corp.');
+        $registrantNameId            = new NameId('3');
+        $registrantEmail             = new Email('reg@domain.invalid');
+        $registrantCommonName        = new CommonName('Reginald Waterloo');
+        $registrantSecFacId          = new SecondFactorId('ISFID');
+        $registrantSecFacIdentifier  = new YubikeyPublicId('00028278');
+
+        $this->scenario
+            ->withAggregateId($authorityId)
+            ->given([
+                new IdentityCreatedEvent(
+                    $authorityId,
+                    $authorityInstitution,
+                    $authorityNameId,
+                    $authorityCommonName,
+                    $authorityEmail,
+                    new Locale('en_GB')
+                ),
+                new YubikeySecondFactorBootstrappedEvent(
+                    $authorityId,
+                    $authorityNameId,
+                    $authorityInstitution,
+                    $authorityCommonName,
+                    $authorityEmail,
+                    new Locale('en_GB'),
+                    new SecondFactorId($this->uuid()),
+                    new YubikeyPublicId('00000012')
+                ),
+            ])
+            ->withAggregateId($registrantId)
+            ->given([
+                new IdentityCreatedEvent(
+                    $registrantId,
+                    $registrantInstitution,
+                    $registrantNameId,
+                    $registrantCommonName,
+                    $registrantEmail,
+                    new Locale('en_GB')
+                ),
+                new YubikeyPossessionProvenEvent(
+                    $registrantId,
+                    $registrantInstitution,
+                    $registrantSecFacId,
+                    $registrantSecFacIdentifier,
+                    EmailVerificationWindow::createFromTimeFrameStartingAt(
+                        TimeFrame::ofSeconds(static::$window),
+                        DateTime::now()
+                    ),
+                    'nonce',
+                    $registrantCommonName,
+                    $registrantEmail,
+                    new Locale('en_GB')
+                ),
+                new EmailVerifiedEvent(
+                    $registrantId,
+                    $registrantInstitution,
+                    $registrantSecFacId,
+                    new SecondFactorType('yubikey'),
+                    $registrantSecFacIdentifier,
+                    DateTime::now(),
+                    'REGCODE',
+                    $registrantCommonName,
+                    $registrantEmail,
+                    new Locale('en_GB')
+                ),
+            ])
+            ->when($command);
+    }
+
+    /**
+     * @test
+     * @group command-handler
+     */
     public function a_second_factor_can_be_vetted_even_though_the_sraa_belongs_to_a_different_institution_than_the_registrant()
     {
         $command                         = new VetSecondFactorCommand();


### PR DESCRIPTION
This PR makes it impossible for RAs to vet registrants outside of their institution, except for SRAAs.

This PR also enforces that only Identities with RA privileges can vet second factors.

This relates to SURFnet/Stepup-RA#133.