### PR TITLE
Revert RA-checking and cross-institution vetting check in Identity aggregate

### DIFF
--- a/src/Surfnet/Stepup/Identity/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Identity.php
@@ -326,10 +326,6 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
     ) {
         $this->assertNotForgotten();
 
-        if ($this->registrationAuthority === null) {
-            throw new DomainException('Cannot vet second factor: vetting Identity is not a registration authority');
-        }
-
         /** @var VettedSecondFactor|null $secondFactorWithHighestLoa */
         $secondFactorWithHighestLoa = $this->vettedSecondFactors->getSecondFactorWithHighestLoa();
         $registrantsSecondFactor = $registrant->getVerifiedSecondFactor($registrantsSecondFactorId);
@@ -346,17 +342,6 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
 
         if (!$identityVerified) {
             throw new DomainException('Will not vet second factor when physical identity has not been verified.');
-        }
-
-        $raHasDifferentInstitution = !$registrant->getInstitution()->equals($this->institution);
-        $raIsNotSraa               = !$this->registrationAuthority->getRole()->isSraa();
-
-        if ($raHasDifferentInstitution && $raIsNotSraa) {
-            throw new DomainException(sprintf(
-                'Cannot vet registrant of institution "%s", because the RA belongs to a different institution: "%s"',
-                $registrant->getInstitution()->getInstitution(),
-                $this->institution->getInstitution()
-            ));
         }
 
         $registrant->complyWithVettingOfSecondFactor(

--- a/src/Surfnet/Stepup/Identity/Value/RegistrationAuthorityRole.php
+++ b/src/Surfnet/Stepup/Identity/Value/RegistrationAuthorityRole.php
@@ -71,14 +71,6 @@ final class RegistrationAuthorityRole implements SerializableInterface
         return $this->role === self::ROLE_RAA;
     }
 
-    /**
-     * return bool
-     */
-    public function isSraa()
-    {
-        return $this->role === self::ROLE_SRAA;
-    }
-
     public function jsonSerialize()
     {
         return $this->role;

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
@@ -1092,7 +1092,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
      * @test
      * @group command-handler
      * @runInSeparateProcess
-     * @expectedException Surfnet\StepupMiddleware\CommandHandlingBundle\Exception\UnsupportedLocaleException
+     * @expectedException \Surfnet\StepupMiddleware\CommandHandlingBundle\Exception\UnsupportedLocaleException
      * @expectedExceptionMessage Given locale "fi_FI" is not a supported locale
      */
     public function an_identity_cannot_express_a_preference_for_an_unsupported_locale()


### PR DESCRIPTION
This reverts commit a1543deca6a1f989b12eca2c119644b3fa951a6a, reversing
changes made to 4b0c8a62ef1182754d887529d2f98ca4f20ae291.

In the Identity aggregate, it is not known whether a certain identity is an SRAA or not. If he is an SRAA, the registrationAuthority property is set to null -- contrary to what one might assume.
That is why these checks currently do not work.

In the future, we need to find another way to determine in the Identity aggregate whether the one doing the vetting is a registration authority and whether he is an SRAA.
See: https://www.pivotaltracker.com/story/show/135335407

Reverting this means that, in theory, any Identity can vet a second factor regardless of whether they are within the same institution.
However, these checks are already done by the front-ends: RA and SS.

This reverts work done in PR #160.