### PR TITLE
Fix: Deprovision controller returns error strings instead of array

### DIFF
--- a/src/Surfnet/Stepup/Tests/Helper/UserDataFormatterTest.php
+++ b/src/Surfnet/Stepup/Tests/Helper/UserDataFormatterTest.php
@@ -57,9 +57,7 @@ class UserDataFormatterTest extends TestCase
                 ['name' => 'name1', 'value' => 'some-value-1'],
             ],
             'name' => 'Stepup-Middleware',
-            'message' => [
-                'The application is teetering on the edge of catastrophe!',
-            ],
+            'message' => ['The application is teetering on the edge of catastrophe!'],
         ];
 
         $inputData = [
@@ -71,6 +69,31 @@ class UserDataFormatterTest extends TestCase
             $formatter->format(
                 $inputData,
                 ['The application is teetering on the edge of catastrophe!'],
+            ),
+        );
+    }
+
+    public function test_multiple_errors_result_in_one_errormessage(): void
+    {
+        $formatter = new UserDataFormatter('Stepup-Middleware');
+        $expected = [
+            'status' => 'FAILED',
+            'data' => [
+                ['name' => 'name1', 'value' => 'some-value-1'],
+            ],
+            'name' => 'Stepup-Middleware',
+            'message' => ['The application is teetering on the edge of catastrophe!', 'This and that is wrong.']
+        ];
+
+        $inputData = [
+            'foobar-name1' => 'some-value-1',
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $formatter->format(
+                $inputData,
+                ['The application is teetering on the edge of catastrophe!', 'This and that is wrong.'],
             ),
         );
     }


### PR DESCRIPTION
Prior to this change, the DeprovisionController would return an array of error messages in case something went wrong. This is not the standard behaviour of stepup components. This change ensures the error message is a string.

User lifecycle handles both an array of strings and a string.

Also add a test to ensure a notice is logged if an unknown user is deprovisioned.

Fixes https://github.com/OpenConext/Stepup-Middleware/issues/495