### PR TITLE
Remove CustomLog from middleware-apache2.conf

### DIFF
--- a/docker/conf/middleware-apache2.conf
+++ b/docker/conf/middleware-apache2.conf
@@ -1,7 +1,7 @@
 <Virtualhost *:80>
     ServerName  middleware
     ServerAdmin admin@surf.nl
-    CustomLog /proc/self/fd/1 stepup
+
     DocumentRoot /var/www/html/public
     SetEnv HTTPS on
     SetEnv APP_ENV prod


### PR DESCRIPTION
Match logformat of other stepup components by using container default