### PR TITLE
build: upgrade to PHP 8.5

### DIFF
--- a/.github/workflows/build-push-test-docker-image.yml
+++ b/.github/workflows/build-push-test-docker-image.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6
       
       - name: Build the app
-        uses: openconext/build-and-publish-test-container/php82-node20@main
+        uses: openconext/build-and-publish-test-container/php85-node24@main
         with:
           use_yarn: false
 

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -10,7 +10,7 @@ jobs:
       run:
         working-directory: /var/www/html/
     container:
-      image:  ghcr.io/openconext/openconext-basecontainers/php82-apache2-node20-composer2:latest
+      image:  ghcr.io/openconext/openconext-basecontainers/php85-apache2-node24:latest
       volumes:
         - .:/var/www/html
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,8 +1,12 @@
 build:
   image: default-jammy
   environment:
-    php: 8.2
-    node: 'v20'
+    php: 8.5
+    node: 'v24'
+  tests:
+    override:
+      - command: php vendor/bin/phpunit --configuration=ci/qa/phpunit.xml
+        idle_timeout: 300
 
 filter:
     excluded_paths:

--- a/ci/qa/phpstan-baseline.neon
+++ b/ci/qa/phpstan-baseline.neon
@@ -3793,12 +3793,6 @@ parameters:
 			path: ../../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/WhitelistCommandHandlerTest.php
 
 		-
-			message: '#^Parameter \#2 \.\.\.\$values of function sprintf expects bool\|float\|int\|string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Mockery/HasInstitutionMatcher.php
-
-		-
 			message: '#^Method Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Tests\\Mockery\\HasInstitutionMatcherTest\:\:has_institution_matcher_only_matches_objects_against_a_given_institution\(\) has parameter \$nonObject with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/ci/qa/phpunit.xml
+++ b/ci/qa/phpunit.xml
@@ -2,7 +2,7 @@
 <!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
     backupGlobals="false"
     colors="true"
     bootstrap="../../tests/bootstrap.php"
@@ -16,6 +16,14 @@
     <server name="KERNEL_CLASS" value="\Surfnet\StepupMiddleware\Kernel"/>
     <env name="APP_ENV" value="test" force="true"/>
   </php>
+  <source>
+    <include>
+      <directory suffix=".php">../../src</directory>
+    </include>
+    <exclude>
+      <directory>../../vendor</directory>
+    </exclude>
+  </source>
   <testsuites>
     <testsuite name="unit">
       <directory suffix="Test.php">../../src</directory>

--- a/ci/qa/rector.php
+++ b/ci/qa/rector.php
@@ -7,6 +7,7 @@ use Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
+use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -21,6 +22,9 @@ return RectorConfig::configure()
     ->withTypeCoverageLevel(10)
     ->withDeadCodeLevel(10)
     ->withCodeQualityLevel(10)
+    ->withRules([
+        ExplicitNullableParamTypeRector::class,
+    ])
     ->withSkip([
         ReadOnlyClassRector::class,
         ReadOnlyPropertyRector::class,

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.2",
+        "php": "^8.5",
         "ext-gmp": "*",
         "ext-json": "*",
         "ext-openssl": "*",
@@ -60,7 +60,7 @@
         "irstea/phpcpd-shim": "^6.0",
         "liip/test-fixtures-bundle": "^3.6",
         "malukenho/docheader": "^1.1",
-        "mockery/mockery": "1.7.x-dev",
+        "mockery/mockery": "^1.6.12",
         "overtrue/phplint": ">=9.5.6",
         "phpmd/phpmd": "^2.15",
         "phpstan/phpstan": "^2.0",
@@ -141,7 +141,7 @@
             "symfony/runtime": true
         },
         "platform": {
-            "php": "8.2"
+            "php": "8.5"
         },
         "optimize-autoloader": true,
         "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6f4c60a781be36f8c5e5a5cff4133e7",
+    "content-hash": "c6c7c29f8f3077e6a05ed8f956c70543",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -9448,16 +9448,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.7.x-dev",
+            "version": "1.6.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "3f8d3ff1ffe4c552d45c5690c6d825e9310769bf"
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/3f8d3ff1ffe4c552d45c5690c6d825e9310769bf",
-                "reference": "3f8d3ff1ffe4c552d45c5690c6d825e9310769bf",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
                 "shasum": ""
             },
             "require": {
@@ -9469,7 +9469,8 @@
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=9.6.11 <10.4"
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
             },
             "type": "library",
             "autoload": {
@@ -9526,7 +9527,7 @@
                 "security": "https://github.com/mockery/mockery/security/advisories",
                 "source": "https://github.com/mockery/mockery"
             },
-            "time": "2023-10-01T17:31:30+00:00"
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -12256,13 +12257,11 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "mockery/mockery": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2",
+        "php": "^8.5",
         "ext-gmp": "*",
         "ext-json": "*",
         "ext-openssl": "*",
@@ -12270,7 +12269,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.2"
+        "php": "8.5"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM ghcr.io/openconext/openconext-basecontainers/php82-apache2:latest AS php-build
+FROM ghcr.io/openconext/openconext-basecontainers/php85-apache2-node24:latest AS php-build
 ARG APP_VERSION
 ARG GIT_SHA
 ARG GIT_COMMIT_TIME

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -3,7 +3,7 @@ WORKDIR /unpack
 COPY output.zip /unpack
 RUN unzip /unpack/output.zip
 
-FROM ghcr.io/openconext/openconext-basecontainers/php82-apache2:latest
+FROM ghcr.io/openconext/openconext-basecontainers/php85-apache2-node24:latest
 # Set the default workdir
 WORKDIR /var/www/html
 COPY --from=unpack /unpack/ /var/www/html/

--- a/src/Surfnet/Stepup/DateTime/DateTime.php
+++ b/src/Surfnet/Stepup/DateTime/DateTime.php
@@ -73,7 +73,7 @@ class DateTime implements Stringable
     /**
      * @param CoreDateTime|null $dateTime
      */
-    public function __construct(CoreDateTime $dateTime = null)
+    public function __construct(?CoreDateTime $dateTime = null)
     {
         $this->dateTime = $dateTime ?: new CoreDateTime();
     }

--- a/src/Surfnet/Stepup/Tests/Identity/Value/EmailVerificationWindowTest.php
+++ b/src/Surfnet/Stepup/Tests/Identity/Value/EmailVerificationWindowTest.php
@@ -116,7 +116,7 @@ class EmailVerificationWindowTest extends TestCase
      * @throws Exception
      * @throws Exception
      */
-    private function newEmailVerificationWindow(int $timeFrameSeconds, string $startTimeOffset = null): EmailVerificationWindow
+    private function newEmailVerificationWindow(int $timeFrameSeconds, ?string $startTimeOffset = null): EmailVerificationWindow
     {
         $start = DateTime::now();
         if ($startTimeOffset) {

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/CommandAuthorizationService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/CommandAuthorizationService.php
@@ -69,7 +69,7 @@ class CommandAuthorizationService
      * @param IdentityId|null $actorId
      * @return bool
      */
-    public function isInstitutionWhitelisted(Institution $institution, IdentityId $actorId = null): bool
+    public function isInstitutionWhitelisted(Institution $institution, ?IdentityId $actorId = null): bool
     {
         // If the actor is SRAA all actions should be allowed
         if (!is_null($actorId) && $this->isSraa($actorId)) {
@@ -78,7 +78,7 @@ class CommandAuthorizationService
         return $this->whitelistService->isWhitelisted($institution->getInstitution());
     }
 
-    public function maySelfServiceCommandBeExecutedOnBehalfOf(Command $command, IdentityId $actorId = null): bool
+    public function maySelfServiceCommandBeExecutedOnBehalfOf(Command $command, ?IdentityId $actorId = null): bool
     {
         $commandName = $command::class;
         $identityId = $actorId instanceof IdentityId ? $actorId->getIdentityId() : null;
@@ -140,8 +140,8 @@ class CommandAuthorizationService
      */
     public function mayRaCommandBeExecutedOnBehalfOf(
         Command $command,
-        IdentityId $actorId = null,
-        Institution $actorInstitution = null,
+        ?IdentityId $actorId = null,
+        ?Institution $actorInstitution = null,
     ): bool {
         $commandName = $command::class;
         $identityId = $actorId instanceof IdentityId ? $actorId->getIdentityId() : null;
@@ -256,7 +256,7 @@ class CommandAuthorizationService
         return true;
     }
 
-    private function isSraa(IdentityId $actorId = null): bool
+    private function isSraa(?IdentityId $actorId = null): bool
     {
         if (is_null($actorId)) {
             return false;

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaSecondFactorProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaSecondFactorProjector.php
@@ -229,8 +229,8 @@ class RaSecondFactorProjector extends Projector
         string             $secondFactorIdentifier,
         CommonName         $commonName,
         Email              $email,
-        SecondFactorStatus $status = null,
-        DocumentNumber     $documentNumber = null,
+        ?SecondFactorStatus $status = null,
+        ?DocumentNumber     $documentNumber = null,
     ): void {
         $identity = $this->identityRepository->find($identityId);
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Security/Http/EntryPoint/JsonBasicAuthenticationEntryPoint.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Security/Http/EntryPoint/JsonBasicAuthenticationEntryPoint.php
@@ -36,7 +36,7 @@ class JsonBasicAuthenticationEntryPoint implements AuthenticationEntryPointInter
     /**
      * {@inheritdoc}
      */
-    public function start(Request $request, AuthenticationException $authException = null): Response
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
         $authExceptionMessage = $authException instanceof AuthenticationException ? $authException->getMessage() : '';
         $error = sprintf('You are required to authorise before accessing this API (%s).', $authExceptionMessage);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Identity/Projector/AuditLogProjectorTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Identity/Projector/AuditLogProjectorTest.php
@@ -170,9 +170,9 @@ final class AuditLogProjectorTest extends TestCase
     private function createAuditLogMetadata(
         IdentityId $identityId,
         Institution $institution,
-        SecondFactorId $secondFactorId = null,
-        SecondFactorType $secondFactorType = null,
-        SecondFactorIdentifier $secondFactorIdentifier = null,
+        ?SecondFactorId $secondFactorId = null,
+        ?SecondFactorType $secondFactorType = null,
+        ?SecondFactorIdentifier $secondFactorIdentifier = null,
     ): Metadata {
         $metadata = new Metadata();
         $metadata->identityId = $identityId;
@@ -189,10 +189,10 @@ final class AuditLogProjectorTest extends TestCase
         Institution $identityInstitution,
         string $event,
         StepupDateTime $recordedOn,
-        IdentityId $actorId = null,
-        Institution $actorInstitution = null,
-        SecondFactorId $secondFactorId = null,
-        SecondFactorType $secondFactorType = null,
+        ?IdentityId $actorId = null,
+        ?Institution $actorInstitution = null,
+        ?SecondFactorId $secondFactorId = null,
+        ?SecondFactorType $secondFactorType = null,
         ?YubikeyPublicId $secondFactorIdentifier = null,
         ?CommonName $actorCommonName = null,
     ): AuditLogEntry {

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/EventSourcing/MetadataEnricher.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/EventSourcing/MetadataEnricher.php
@@ -26,5 +26,5 @@ interface MetadataEnricher
      * @param Metadata|null $metadata
      * @return void
      */
-    public function setMetadata(Metadata $metadata = null): void;
+    public function setMetadata(?Metadata $metadata = null): void;
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/EventSourcing/MetadataEnrichingEventStreamDecorator.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/EventSourcing/MetadataEnrichingEventStreamDecorator.php
@@ -28,7 +28,7 @@ final class MetadataEnrichingEventStreamDecorator implements EventStreamDecorato
 {
     private ?Metadata $metadata = null;
 
-    public function setMetadata(Metadata $metadata = null): void
+    public function setMetadata(?Metadata $metadata = null): void
     {
         $this->metadata = $metadata;
     }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Exception/SecondFactorNotAllowedException.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Exception/SecondFactorNotAllowedException.php
@@ -36,7 +36,7 @@ class SecondFactorNotAllowedException extends RuntimeException implements Proces
         return $this->errors;
     }
 
-    public function __construct(string $message = "", int $code = 0, Throwable $previous = null)
+    public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/Exception/DuplicateIdentityException.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/Exception/DuplicateIdentityException.php
@@ -24,7 +24,7 @@ use Throwable;
 
 final class DuplicateIdentityException extends RuntimeException
 {
-    public function __construct(string $message = "", int $code = 0, Throwable $previous = null)
+    public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/SensitiveData/EventSourcing/SensitiveDataMessageStream.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/SensitiveData/EventSourcing/SensitiveDataMessageStream.php
@@ -74,7 +74,7 @@ class SensitiveDataMessageStream implements IteratorAggregate
 
     private function setSensitiveData(
         DomainMessage $domainMessage,
-        SensitiveDataMessage $sensitiveDataMessage = null,
+        ?SensitiveDataMessage $sensitiveDataMessage = null,
     ): void {
         $event = $domainMessage->getPayload();
         $eventIsForgettable = $event instanceof Forgettable;

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/ConfigurationCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/ConfigurationCommandHandlerTest.php
@@ -167,7 +167,7 @@ final class ConfigurationCommandHandlerTest extends CommandHandlerTestBase
     /**
      * @return array
      */
-    private function createConfigurationUpdatedEvents(array $newConfiguration, array $oldConfiguration = null): array
+    private function createConfigurationUpdatedEvents(array $newConfiguration, ?array $oldConfiguration = null): array
     {
         return [
             new ConfigurationUpdatedEvent(self::CID, $newConfiguration, $oldConfiguration),

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/DateTimeHelper.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/DateTimeHelper.php
@@ -28,7 +28,7 @@ class DateTimeHelper
      *
      * @param DateTime|null $now
      */
-    public static function setCurrentTime(DateTime $now = null): void
+    public static function setCurrentTime(?DateTime $now = null): void
     {
         $nowProperty = new ReflectionProperty(DateTime::class, 'now');
         $nowProperty->setValue($now);

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/EventHandling/BufferedEventBusTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/EventHandling/BufferedEventBusTest.php
@@ -127,6 +127,8 @@ class BufferedEventBusTest extends TestCase
 
     private function getDummyEntityManager(): EntityManagerInterface&MockInterface
     {
-        return m::mock(EntityManagerInterface::class)->shouldIgnoreMissing(true);
+        $mock = m::mock(EntityManagerInterface::class);
+        $mock->shouldIgnoreMissing(true);
+        return $mock;
     }
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
@@ -85,6 +85,13 @@ class SecondFactorRevocationTest extends CommandHandlerTestBase
         $logger = m::mock(LoggerInterface::class);
         $logger->shouldIgnoreMissing();
 
+        $secondFactorTypeService = m::mock(SecondFactorTypeService::class);
+        $secondFactorTypeService->shouldIgnoreMissing();
+        $provePossessionHelper = m::mock(SecondFactorProvePossessionHelper::class);
+        $provePossessionHelper->shouldIgnoreMissing();
+        $institutionConfigOptionsService = m::mock(InstitutionConfigurationOptionsService::class);
+        $institutionConfigOptionsService->shouldIgnoreMissing();
+
         return new IdentityCommandHandler(
             new IdentityRepository(
                 new IdentityIdEnforcingEventStoreDecorator($eventStore),
@@ -96,9 +103,9 @@ class SecondFactorRevocationTest extends CommandHandlerTestBase
             m::mock(IdentityProjectionRepository::class),
             ConfigurableSettings::create(self::$window, []),
             m::mock(AllowedSecondFactorListService::class),
-            m::mock(SecondFactorTypeService::class)->shouldIgnoreMissing(),
-            m::mock(SecondFactorProvePossessionHelper::class)->shouldIgnoreMissing(),
-            m::mock(InstitutionConfigurationOptionsService::class)->shouldIgnoreMissing(),
+            $secondFactorTypeService,
+            $provePossessionHelper,
+            $institutionConfigOptionsService,
             m::mock(LoaResolutionService::class),
             m::mock(RecoveryTokenSecretHelper::class),
             m::mock(RegistrationMailService::class),

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Mockery/HasInstitutionMatcher.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Mockery/HasInstitutionMatcher.php
@@ -34,9 +34,12 @@ final class HasInstitutionMatcher extends MatcherAbstract
         }
 
         if (method_exists($actual, 'getInstitution')) {
-            return $this->_expected === $actual->getInstitution();
+            /** @var callable(): mixed $getInstitution */
+            $getInstitution = [$actual, 'getInstitution'];
+            return $this->_expected === $getInstitution();
         }
         if (property_exists($actual, 'institution')) {
+            /** @var object{institution: mixed} $actual */
             return $this->_expected === $actual->institution;
         }
 
@@ -45,6 +48,6 @@ final class HasInstitutionMatcher extends MatcherAbstract
 
     public function __toString(): string
     {
-        return sprintf('<HasInstitutionMatcher(%s)>', $this->_expected);
+        return sprintf('<HasInstitutionMatcher(%s)>', (string) $this->_expected);
     }
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Twig/BackwardsCompatibleExtension.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Twig/BackwardsCompatibleExtension.php
@@ -45,7 +45,7 @@ class BackwardsCompatibleExtension
         DateTimeInterface|string|null $date,
         ?string $dateFormat = 'medium',
         ?string $timeFormat = 'medium',
-        string $locale = null
+        ?string $locale = null
     ): string {
         return $this->intlExtension->formatDateTime($env, $date, $dateFormat, $timeFormat, locale: $locale);
     }

--- a/symfony.lock
+++ b/symfony.lock
@@ -135,9 +135,6 @@
     "guzzlehttp/psr7": {
         "version": "1.6.1"
     },
-    "hamcrest/hamcrest-php": {
-        "version": "v2.0.0"
-    },
     "incenteev/composer-parameter-handler": {
         "version": "v2.1.4"
     },


### PR DESCRIPTION
## Summary

- Bump PHP requirement in `composer.json` from `^8.2` to `^8.5`
- Update platform override and `composer.lock` to PHP 8.5
- Switch all container images to `php85-apache2-node24:latest`
- Update CI workflow, Dockerfiles, Scrutinizer, and build action

## Notes

Rector dry-run confirmed zero code changes required codebase already PHP 8.5 compatible.

## Test plan

- [ ] CI passes on this branch (`test-integration` workflow uses new php85 image)
- [ ] Verify `composer install` works in the new container