### PR TITLE
Skip events on identical whitelist and config pushes

### DIFF
--- a/src/Surfnet/Stepup/Configuration/Configuration.php
+++ b/src/Surfnet/Stepup/Configuration/Configuration.php
@@ -50,6 +50,13 @@ class Configuration extends EventSourcedAggregateRoot implements ConfigurationIn
     {
         $decodedConfiguration = JsonHelper::decode($newConfiguration);
 
+        if ($this->configuration !== null
+            && is_array($decodedConfiguration)
+            && $this->deepKsort($this->configuration) === $this->deepKsort($decodedConfiguration)
+        ) {
+            return;
+        }
+
         $this->apply(
             new ConfigurationUpdatedEvent(
                 self::CONFIGURATION_ID,
@@ -80,5 +87,23 @@ class Configuration extends EventSourcedAggregateRoot implements ConfigurationIn
     public function applyConfigurationUpdatedEvent(ConfigurationUpdatedEvent $event): void
     {
         $this->configuration = $event->newConfiguration;
+    }
+
+    /**
+     * @param array<string|int, mixed> $array
+     * @return array<string|int, mixed>
+     */
+    private function deepKsort(array $array): array
+    {
+        ksort($array);
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $array[$key] = $this->deepKsort($value);
+            }
+        }
+        if (array_is_list($array)) {
+            usort($array, fn($a, $b) => json_encode($a) <=> json_encode($b));
+        }
+        return $array;
     }
 }

--- a/src/Surfnet/Stepup/Identity/Collection/InstitutionCollection.php
+++ b/src/Surfnet/Stepup/Identity/Collection/InstitutionCollection.php
@@ -120,6 +120,15 @@ final class InstitutionCollection implements IteratorAggregate, JsonSerializable
         return new self($institutions);
     }
 
+    public function equals(self $other): bool
+    {
+        $a = $this->serialize();
+        $b = $other->serialize();
+        sort($a);
+        sort($b);
+        return $a === $b;
+    }
+
     public function serialize(): array
     {
         return array_map(fn(Institution $institution): string => (string)$institution, $this->elements);

--- a/src/Surfnet/Stepup/Identity/Whitelist.php
+++ b/src/Surfnet/Stepup/Identity/Whitelist.php
@@ -55,6 +55,10 @@ final class Whitelist extends EventSourcedAggregateRoot implements WhitelistApi
 
     public function replaceAll(InstitutionCollection $institutionCollection): void
     {
+        if ($this->whitelist !== null && $this->whitelist->equals($institutionCollection)) {
+            return;
+        }
+
         $this->apply(new WhitelistReplacedEvent($institutionCollection));
     }
 

--- a/src/Surfnet/Stepup/Tests/Identity/Collection/InstitutionCollectionTest.php
+++ b/src/Surfnet/Stepup/Tests/Identity/Collection/InstitutionCollectionTest.php
@@ -154,6 +154,58 @@ class InstitutionCollectionTest extends UnitTest
         }
     }
 
+    #[Test]
+    #[Group('domain')]
+    #[Group('whitelist')]
+    public function two_empty_collections_are_equal(): void
+    {
+        $this->assertTrue((new InstitutionCollection())->equals(new InstitutionCollection()));
+    }
+
+    #[Test]
+    #[Group('domain')]
+    #[Group('whitelist')]
+    public function collections_with_same_institutions_are_equal(): void
+    {
+        $a = new InstitutionCollection([new Institution('surf.nl'), new Institution('example.com')]);
+        $b = new InstitutionCollection([new Institution('surf.nl'), new Institution('example.com')]);
+
+        $this->assertTrue($a->equals($b));
+    }
+
+    #[Test]
+    #[Group('domain')]
+    #[Group('whitelist')]
+    public function collections_with_same_institutions_in_different_order_are_equal(): void
+    {
+        $a = new InstitutionCollection([new Institution('surf.nl'), new Institution('example.com')]);
+        $b = new InstitutionCollection([new Institution('example.com'), new Institution('surf.nl')]);
+
+        $this->assertTrue($a->equals($b));
+    }
+
+    #[Test]
+    #[Group('domain')]
+    #[Group('whitelist')]
+    public function a_subset_is_not_equal_to_the_superset(): void
+    {
+        $a = new InstitutionCollection([new Institution('surf.nl')]);
+        $b = new InstitutionCollection([new Institution('surf.nl'), new Institution('example.com')]);
+
+        $this->assertFalse($a->equals($b));
+    }
+
+    #[Test]
+    #[Group('domain')]
+    #[Group('whitelist')]
+    public function collections_with_different_institutions_are_not_equal(): void
+    {
+        $a = new InstitutionCollection([new Institution('surf.nl')]);
+        $b = new InstitutionCollection([new Institution('example.com')]);
+
+        $this->assertFalse($a->equals($b));
+    }
+
     /**
      * @return list<Institution>
      */

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/ConfigurationCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/ConfigurationCommandHandlerTest.php
@@ -110,6 +110,56 @@ final class ConfigurationCommandHandlerTest extends CommandHandlerTestBase
             ->then($this->createConfigurationUpdatedEvents($configuration2, $configuration1));
     }
 
+    #[Test]
+    #[Group('command-handler')]
+    public function pushing_configuration_with_different_key_order_does_not_add_events(): void
+    {
+        $configuration = [
+            'gateway' => [
+                'identity_providers' => [],
+                'service_providers' => [],
+            ],
+        ];
+
+        $command = new UpdateConfigurationCommand();
+        // Same content but JSON keys in reversed order
+        $command->configuration = '{"gateway":{"service_providers":[],"identity_providers":[]}}';
+
+        $this->scenario
+            ->withAggregateId(self::CID)
+            ->given(
+                array_merge(
+                    [$this->createNewConfigurationCreatedEvent()],
+                    $this->createConfigurationUpdatedEvents($configuration, null),
+                ),
+            )
+            ->when($command)
+            ->then([]);
+    }
+
+    #[Test]
+    #[Group('command-handler')]
+    public function pushing_the_same_configuration_again_does_not_add_events(): void
+    {
+        $configuration = [
+            'gateway' => [
+                'identity_providers' => [],
+                'service_providers' => [],
+            ],
+        ];
+
+        $this->scenario
+            ->withAggregateId(self::CID)
+            ->given(
+                array_merge(
+                    [$this->createNewConfigurationCreatedEvent()],
+                    $this->createConfigurationUpdatedEvents($configuration, null),
+                ),
+            )
+            ->when($this->createUpdateCommand($configuration))
+            ->then([]);
+    }
+
     protected function createCommandHandler(
         EventStoreInterface $eventStore,
         EventBusInterface $eventBus,
@@ -143,7 +193,7 @@ final class ConfigurationCommandHandlerTest extends CommandHandlerTestBase
     /**
      * @return array
      */
-    private function createConfigurationUpdatedEvents(array $newConfiguration, array $oldConfiguration = null): array
+    private function createConfigurationUpdatedEvents(array $newConfiguration, ?array $oldConfiguration = null): array
     {
         return [
             new ConfigurationUpdatedEvent(self::CID, $newConfiguration, $oldConfiguration),

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/WhitelistCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/WhitelistCommandHandlerTest.php
@@ -97,6 +97,46 @@ class WhitelistCommandHandlerTest extends CommandHandlerTestBase
     #[Test]
     #[Group('command-handler')]
     #[Group('whitelist')]
+    public function replacing_whitelist_with_identical_institutions_does_not_add_an_event(): void
+    {
+        $institutions = $this->mapStringValuesToInstitutions(['Institution A', 'Institution B']);
+
+        $command = new ReplaceWhitelistCommand();
+        $command->institutions = ['Institution A', 'Institution B'];
+
+        $this->scenario
+            ->withAggregateId(self::WID)
+            ->given([
+                new WhitelistCreatedEvent(new InstitutionCollection()),
+                new WhitelistReplacedEvent(new InstitutionCollection($institutions)),
+            ])
+            ->when($command)
+            ->then([]);
+    }
+
+    #[Test]
+    #[Group('command-handler')]
+    #[Group('whitelist')]
+    public function replacing_whitelist_with_same_institutions_in_different_order_does_not_add_an_event(): void
+    {
+        $institutions = $this->mapStringValuesToInstitutions(['Institution A', 'Institution B']);
+
+        $command = new ReplaceWhitelistCommand();
+        $command->institutions = ['Institution B', 'Institution A'];
+
+        $this->scenario
+            ->withAggregateId(self::WID)
+            ->given([
+                new WhitelistCreatedEvent(new InstitutionCollection()),
+                new WhitelistReplacedEvent(new InstitutionCollection($institutions)),
+            ])
+            ->when($command)
+            ->then([]);
+    }
+
+    #[Test]
+    #[Group('command-handler')]
+    #[Group('whitelist')]
     public function an_institution_not_yet_on_the_whitelist_can_be_added_to_the_whitelist(): void
     {
         $initialInstitutions = $this->mapStringValuesToInstitutions(['Initial One', 'Initial Two']);

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Controller/ConfigurationControllerTest.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Controller/ConfigurationControllerTest.php
@@ -44,6 +44,8 @@ class ConfigurationControllerTest extends WebTestCase
 
     private AbstractDatabaseTool $databaseTool;
 
+    private Connection $connection;
+
     public function setUp(): void
     {
         $this->client = static::createClient();
@@ -56,12 +58,14 @@ class ConfigurationControllerTest extends WebTestCase
         $this->databaseTool->setExcludedDoctrineTables(['ra_candidate']);
         $this->databaseTool->loadFixtures([]);
 
+        $connection = $this->client->getContainer()->get('doctrine.dbal.middleware_connection');
+        assert($connection instanceof Connection);
+        $this->connection = $connection;
+
         // Broadway event store table is not managed by Doctrine ORM; create it manually for the test DB.
         $eventStore = $this->client->getContainer()->get('surfnet_stepup.event_store.dbal');
         assert($eventStore instanceof DBALEventStore);
-        $connection = $this->client->getContainer()->get('doctrine.dbal.middleware_connection');
-        assert($connection instanceof Connection);
-        $schemaManager = $connection->createSchemaManager();
+        $schemaManager = $this->connection->createSchemaManager();
         $table = $eventStore->configureTable();
         if (!$schemaManager->tablesExist(['event_stream'])) {
             $schemaManager->createTable($table);
@@ -206,40 +210,19 @@ class ConfigurationControllerTest extends WebTestCase
     #[Group('management')]
     public function validPushWithOnlyGatewayIsAccepted(): void
     {
-        $configuration = json_encode([
+        $this->pushConfiguration([
             'gateway' => [
                 'identity_providers' => [],
                 'service_providers' => [self::minimalServiceProvider()],
             ],
         ]);
-        assert(is_string($configuration));
-
-        $this->client->request(
-            'POST',
-            '/management/configuration',
-            [],
-            [],
-            [
-                'HTTP_ACCEPT' => 'application/json',
-                'CONTENT_TYPE' => 'application/json',
-                'PHP_AUTH_USER' => 'management',
-                'PHP_AUTH_PW' => $this->password,
-            ],
-            $configuration,
-        );
-
-        $this->assertSame(
-            Response::HTTP_OK,
-            $this->client->getResponse()->getStatusCode(),
-            (string) $this->client->getResponse()->getContent(),
-        );
     }
 
     #[Test]
     #[Group('management')]
     public function pushWithSraaAndEmailTemplatesIsSilentlyAccepted(): void
     {
-        $configuration = json_encode([
+        $this->pushConfiguration([
             'gateway' => [
                 'identity_providers' => [],
                 'service_providers' => [self::minimalServiceProvider()],
@@ -249,33 +232,58 @@ class ConfigurationControllerTest extends WebTestCase
                 'confirm_email' => ['en_GB' => 'Verify {{ commonName }}'],
             ],
         ]);
-        assert(is_string($configuration));
-
-        $this->client->request(
-            'POST',
-            '/management/configuration',
-            [],
-            [],
-            [
-                'HTTP_ACCEPT' => 'application/json',
-                'CONTENT_TYPE' => 'application/json',
-                'PHP_AUTH_USER' => 'management',
-                'PHP_AUTH_PW' => $this->password,
-            ],
-            $configuration,
-        );
-
-        $this->assertSame(
-            Response::HTTP_OK,
-            $this->client->getResponse()->getStatusCode(),
-            (string) $this->client->getResponse()->getContent(),
-        );
 
         $content = $this->client->getResponse()->getContent();
         assert(is_string($content));
         $response = json_decode($content, true);
         assert(is_array($response));
         $this->assertEquals('OK', $response['status']);
+    }
+
+    #[Test]
+    #[Group('management')]
+    public function pushing_configuration_with_reordered_service_providers_does_not_emit_new_events(): void
+    {
+        $spA = array_merge(self::minimalServiceProvider(), ['entity_id' => 'https://sp-a.example.com/metadata']);
+        $spB = array_merge(self::minimalServiceProvider(), ['entity_id' => 'https://sp-b.example.com/metadata']);
+
+        $this->pushConfiguration(['gateway' => ['identity_providers' => [], 'service_providers' => [$spA, $spB]]]);
+        $eventCountAfterFirstPush = $this->getEventStreamCount();
+
+        $this->pushConfiguration(['gateway' => ['identity_providers' => [], 'service_providers' => [$spB, $spA]]]);
+
+        $this->assertSame(
+            $eventCountAfterFirstPush,
+            $this->getEventStreamCount(),
+            'Reordering service providers should not emit new events',
+        );
+    }
+
+    /** @param array<mixed> $configuration */
+    private function pushConfiguration(array $configuration): void
+    {
+        $encoded = json_encode($configuration);
+        assert(is_string($encoded));
+
+        $this->client->request('POST', '/management/configuration', [], [], [
+            'HTTP_ACCEPT' => 'application/json',
+            'CONTENT_TYPE' => 'application/json',
+            'PHP_AUTH_USER' => 'management',
+            'PHP_AUTH_PW' => $this->password,
+        ], $encoded);
+
+        $this->assertSame(
+            Response::HTTP_OK,
+            $this->client->getResponse()->getStatusCode(),
+            (string) $this->client->getResponse()->getContent(),
+        );
+    }
+
+    private function getEventStreamCount(): int
+    {
+        $result = $this->connection->fetchOne('SELECT COUNT(*) FROM event_stream');
+        assert(is_string($result) || is_int($result));
+        return (int) $result;
     }
 
     /** @return array<string, mixed> */


### PR DESCRIPTION
## Summary

- Add `InstitutionCollection::equals()` for order-independent comparison
- Guard `Whitelist::replaceAll()` — no `WhitelistReplacedEvent` if content unchanged
- Guard `Configuration::update()` — no events if decoded config unchanged
- `InstitutionConfiguration` already had correct equality guards per-field; no change needed

## Why

With manage pushing config hundreds of times per day (per [OpenConext/OpenConext-manage#627](https://github.com/OpenConext/OpenConext-manage/issues/627)), all three replace endpoints (`/management/whitelist/replace`, `/management/configuration`, `/management/institution-configuration`) were adding events on every push regardless of whether anything changed.

## Test plan

- [ ] Unit tests added for whitelist and config idempotent push scenarios
- [ ] Behat tests added in devconf (`mw_idempotent_push.feature`) to verify event stream count does not grow on duplicate pushes

Closes #587

> **Note:** This PR targets `feature/issue-583-email-templates-to-disk` (PR #595) as its base, since it depends on the clean `Configuration::update()` from that branch. It should be rebased onto `main` after #595 merges.